### PR TITLE
Fix devide by zero bug and properly handle exponential backoff with an alert_after. Closes #2

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -170,12 +170,11 @@ BODY
       # Special case of exponential backoff
       if realert_every.to_i == -1
         # If our number of failed attempts is an exponent of 2^
-        if (Math::log(number_of_failed_attempts) / Math::log(2)) % 1 == 0
+        if power_of_two?(number_of_failed_attempts)
           # Then This is our MOMENT!
-          realert_every = number_of_failed_attempts
+          return nil
         else
-          # Fake realert to be higher so we dont alert
-          realert_every = number_of_failed_attempts + 1
+          bail 'not on a power of two: ' + number_of_failed_attempts.to_s
         end
       end
       if number_of_failed_attempts == 1
@@ -183,13 +182,17 @@ BODY
         return nil
       end
       # Now bail if we are not in the realert_every cycle
-      unless number_of_failed_attempts == 0 || number_of_failed_attempts % realert_every == 0
+      unless number_of_failed_attempts == 0 || number_of_failed_attempts % realert_every.to_i == 0
         bail 'only handling every ' + realert_every.to_s + ' occurrences, and we are at ' + number_of_failed_attempts.to_s
-# DEBUG
-#      else
-#        puts 'Continuing because we realert every ' + realert_every.to_s + ' and we are at ' + number_of_failed_attempts.to_s
       end
     end
+  end
+
+  def power_of_two?(x)
+    while ( x % 2) == 0 and x > 1
+      x /= 2
+    end
+    x==1
   end
 
 end

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -229,6 +229,72 @@ describe BaseHandler do
         expect(subject.filter_repeated).to eql(nil)
       end
     end
+    context "When exponential backoff, and alert_after, it should not alert the first time" do
+      it do
+        subject.event['occurrences'] = 1
+        subject.event['check']['interval'] = 20
+        subject.event['check']['realert_every'] = "-1"
+        subject.event['check']['alert_after'] = 60
+        subject.event['action'] = 'create'
+        expect(subject).to receive(:bail).and_return(nil).once
+        expect(subject.filter_repeated).to eql(nil)
+      end
+    end
+    context "When exponential backoff, and alert_after, it should not alert the second time" do
+      it do
+        subject.event['occurrences'] = 2
+        subject.event['check']['interval'] = 20
+        subject.event['check']['realert_every'] = "-1"
+        subject.event['check']['alert_after'] = 60
+        subject.event['action'] = 'create'
+        expect(subject).to receive(:bail).and_return(nil).once
+        expect(subject.filter_repeated).to eql(nil)
+      end
+    end
+    context "When exponential backoff, and alert_after, it should not alert the third time" do
+      it do
+        subject.event['occurrences'] = 3
+        subject.event['check']['interval'] = 20
+        subject.event['check']['realert_every'] = "-1"
+        subject.event['check']['alert_after'] = 60
+        subject.event['action'] = 'create'
+        expect(subject).to receive(:bail).and_return(nil).once
+        expect(subject.filter_repeated).to eql(nil)
+      end
+    end
+    context "When exponential backoff, and alert_after, it should alert the forth time" do
+      it do
+        subject.event['occurrences'] = 4
+        subject.event['check']['interval'] = 20
+        subject.event['check']['realert_every'] = "-1"
+        subject.event['check']['alert_after'] = 60
+        subject.event['action'] = 'create'
+        expect(subject).not_to receive(:bail)
+        expect(subject.filter_repeated).to eql(nil)
+      end
+    end
+    context "When exponential backoff, and alert_after, it should not alert the fith time" do
+      it do
+        subject.event['occurrences'] = 5
+        subject.event['check']['interval'] = 20
+        subject.event['check']['realert_every'] = "-1"
+        subject.event['check']['alert_after'] = 60
+        subject.event['action'] = 'create'
+        expect(subject).not_to receive(:bail)
+        expect(subject.filter_repeated).to eql(nil)
+      end
+    end
+    context "When exponential backoff, and alert_after, it should not alert the sixth time" do
+      it do
+        subject.event['occurrences'] = 6
+        subject.event['check']['interval'] = 20
+        subject.event['check']['realert_every'] = "-1"
+        subject.event['check']['alert_after'] = 60
+        subject.event['action'] = 'create'
+        expect(subject).to receive(:bail).and_return(nil).once
+        expect(subject.filter_repeated).to eql(nil)
+      end
+    end
   end #End filter repeated
 
 end # End describe  


### PR DESCRIPTION
Primary: @bobtfish  or @hashbrowncipher 

This fixes #2 where we get divide by zero errors.

This was a hard to track down situation that only occurred when we had an alert_after and exponential backoff.

I hope I've made this filtering logic a bit more clear. Luckily we have tests!!! So using this new power-of-two function allowed me to be sure it still is legit.
