### PR TITLE
Uncolorize output to handle checks that have color

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,4 +6,4 @@ fixtures:
     monitoring_check: "https://github.com/Yelp/puppet-monitoring_check"
     sensu: "https://github.com/sensu/sensu-puppet"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
-
+    apt: "https://github.com/puppetlabs/puppetlabs-apt"

--- a/files/base.rb
+++ b/files/base.rb
@@ -4,6 +4,9 @@
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
 
+# Taken from https://github.com/flori/term-ansicolor/blob/e6086b7fddf53c53f8022acc1920f435e65b5e51/lib/term/ansicolor.rb#L60
+COLOR_REGEX = /\e\[(?:(?:[349]|10)[0-7]|[0-9]|[34]8;5;\d{1,3})?m/
+
 class BaseHandler < Sensu::Handler
   def event_is_ok?
     @event['check']['status'] == 0
@@ -28,6 +31,10 @@ class BaseHandler < Sensu::Handler
     else
       'UNKNOWN'
     end
+  end
+
+  def uncolorize(input)
+    input.gsub(COLOR_REGEX, '')
   end
 
   def should_page?
@@ -84,7 +91,7 @@ class BaseHandler < Sensu::Handler
 
   def full_description
     body = <<-BODY
-#{@event['check']['output']}
+#{uncolorize(@event['check']['output'])}
 
 Dashboard Link: #{dashboard_link}
 Runbook: #{runbook}
@@ -107,7 +114,7 @@ BODY
 
   def full_description_hash
     {
-      'Output' => @event['check']['output'],
+      'Output' => uncolorize(@event['check']['output']),
       'Dashboard Link' => dashboard_link,
       'Host' => @event['client']['name'],
       'Timestamp' => Time.at(@event['check']['issued']),

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,9 +1,17 @@
 require 'spec_helper'
 
 describe 'sensu_handlers', :type => :class do
+
+
+  let(:facts) {{
+    :osfamily => 'Debian',
+    :lsbdistid => 'debian',
+  }}
+
   context 'By default, it needs teams to be provided' do
     it { should_not compile }
   end
+
   context 'With teams' do
     let(:teams) {{
       'operations' => {}
@@ -19,5 +27,6 @@ describe 'sensu_handlers', :type => :class do
     }}
     it { should compile }
   end
+
 end
 

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -125,7 +125,22 @@ describe BaseHandler do
     it "should have the responsible team name in the description" do
       expect(subject.full_description).to match("Team: someotherteam")
     end
-    
+  end
+
+  context "Color filtering" do
+     before(:each) do
+      setup_event! do |e|
+        e['check']['runbook'] = 'http://some.runbook/'
+        e['check']['team'] = 'someotherteam'
+        e['check']['output'] = '[36mTEST[36mOUTPUT[0m'
+      end
+    end
+    it "should strip the colors in full_description" do
+      expect(subject.full_description).to match("^TESTOUTPUT\n")
+    end
+    it "should strip the colors in description" do
+      expect(subject.full_description_hash['Output']).to match("^TESTOUTPUT$")
+    end
   end
 
   context "check filter_repeated" do


### PR DESCRIPTION
Primary: @bobtfish 
cc @mrtyler 

This makes our sensu handlers strip color on output.

I know that the *right* thing to do is to have all tools detect a non-tty and not spit out color, but this makes our handlers tolerant of this behavior and strips all ansi color codes on output that doesn't support it. (pagerduty/email)

