### PR TITLE
Make the status output be human readable

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -98,7 +98,7 @@ Runbook: #{runbook}
 Tip: #{tip}
 
 Command:  #{@event['check']['command']}
-Status:  #{@event['check']['status']}
+Status: #{human_check_status()} (#{@event['check']['status']})
 
 Timestamp: #{Time.at(@event['check']['issued'])}
 Occurrences:  #{@event['occurrences']}
@@ -121,7 +121,7 @@ BODY
       'Address' => @event['client']['address'],
       'Check Name' => @event['check']['name'],
       'Command' => @event['check']['command'],
-      'Status' => @event['check']['status'],
+      'Status' => "#{human_check_status()} (#{@event['check']['status']})",
       'Occurrences' => @event['occurrences'],
       'Team' => team_name,
       'Runbook' => runbook,

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -122,8 +122,9 @@ describe BaseHandler do
         e['check']['team'] = 'someotherteam'
       end
     end
-    it "should have the responsible team name in the description" do
-      expect(subject.full_description).to match("Team: someotherteam")
+    it "should correctly format the output" do
+      expect(subject.full_description).to include("Team: someotherteam")
+      expect(subject.full_description).to include("Status: CRITICAL (2)")
     end
   end
 


### PR DESCRIPTION
This is to satisfy internal ticket PAASTA-88

This makes it so emails/pagerduty/etc have a human readable status output first, then the numeric value in parens.

cc @bobtfish @mrtyler 

I couldn't get "match" to match this for whatever reason so I used the include match instead?
https://www.relishapp.com/rspec/rspec-expectations/v/2-0/docs/matchers/include-matcher