### PR TITLE
Set dashboard link to go directly to the check

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -130,7 +130,8 @@ BODY
   end
 
   def dashboard_link
-    settings['default']['dashboard_link'] || 'Unknown dashboard link. Please set for the base handler config'
+    settings['default']['dashboard_link'].gsub(/\/$/, '')
+    "#{settings['default']['dashboard_link']}/#/client/#{settings['default']['region']}/#{@event['client']['name']}?check=#{@event['check']['name']}" || 'Unknown dashboard link. Please set for the base handler config'
   end
 
   def log(line)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,7 @@ class sensu_handlers(
     handlers  => $default_handler_array,
     config    => {
       dashboard_link => $dashboard_link,
+      region         => $region,
     }
   }
 

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -29,6 +29,10 @@ describe BaseHandler do
     it('has no runbook') { expect(subject.runbook).to eql(false) }
   end
 
+  context "dashboard link is correctly compiled" do
+    it('has correct link') { expect(subject.dashboard_link).to eql('test_dashboard_link/#/client/data_center/some.client?check=mycoolcheck') }
+  end
+
   context "Settings can be overridden from check metadata" do
     before(:each) do
       setup_event! do |e|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ module SensuHandlerTestHelper
     subject.settings          = Hash.new
     subject.settings['default']  = Hash.new
     subject.settings['default']['dashboard_link'] = 'test_dashboard_link'
+    subject.settings['default']['region'] = 'data_center'
     subject.settings[settings_key] ||= Hash.new
     subject.settings[settings_key]['teams'] ||= Hash.new
     subject.settings[settings_key]['teams']['operations'] = {


### PR DESCRIPTION
At present, the dashboard link that is sent is the base url - ```http://sensu.region``` by default. We can leverage existing data to link directly to the check that has alerted ```http://sensu.region/#/client/region/client.name?check=check.name````. 

Obviously, this will only work with Uchiwa, but that has been the default dashboard in Sensu for several releases. Would it be worth adding an is_uchiwa switch for this?