### PR TITLE
Don't override region

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -131,7 +131,7 @@ BODY
 
   def dashboard_link
     settings['default']['dashboard_link'].gsub(/\/$/, '')
-    "#{settings['default']['dashboard_link']}/#/client/#{settings['default']['region']}/#{@event['client']['name']}?check=#{@event['check']['name']}" || 'Unknown dashboard link. Please set for the base handler config'
+    "#{settings['default']['dashboard_link']}/#/client/#{settings['default']['datacenter']}/#{@event['client']['name']}?check=#{@event['check']['name']}" || 'Unknown dashboard link. Please set for the base handler config'
   end
 
   def log(line)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,7 @@ class sensu_handlers(
   $include_graphite      = true,
   $include_aws_prune     = true,
   $region                = $::datacenter,
+  $datacenter            = $::datacenter,
   $dashboard_link        = "https://sensu.${::domain}",
 ) {
 
@@ -68,7 +69,7 @@ class sensu_handlers(
     handlers  => $default_handler_array,
     config    => {
       dashboard_link => $dashboard_link,
-      region         => $region,
+      datacenter     => $datacenter,
     }
   }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ module SensuHandlerTestHelper
     subject.settings          = Hash.new
     subject.settings['default']  = Hash.new
     subject.settings['default']['dashboard_link'] = 'test_dashboard_link'
-    subject.settings['default']['region'] = 'data_center'
+    subject.settings['default']['datacenter'] = 'data_center'
     subject.settings[settings_key] ||= Hash.new
     subject.settings[settings_key]['teams'] ||= Hash.new
     subject.settings[settings_key]['teams']['operations'] = {


### PR DESCRIPTION
Previously, I used region as the basis for the link. This is wrong for two reasons:

1) Uchiwa uses the concept of data centers to group clients and events, not region
2) Region is required by AWS functions, and should not be touched.