### PR TITLE
It's useful to have the server hostname

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -125,7 +125,8 @@ BODY
       'Occurrences' => @event['occurrences'],
       'Team' => team_name,
       'Runbook' => runbook,
-      'Tip' => tip
+      'Tip' => tip,
+      'Server' => Socket.gethostname,
     }
   end
 


### PR DESCRIPTION
I'm being paged by a machine I just bootstrapped for a new environment (before that environment had sensu servers), and I don't know if I'm being paged by the old environment (as I moved the client to the new env), or by the sensu server I built in the new environment.

Having this in the event data would be useful, and save me from having to do further debugging.