### PR TITLE
Remove explicit require json/pure from cache_instance_list.rb

### DIFF
--- a/files/cache_instance_list.rb
+++ b/files/cache_instance_list.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'fog'
-require 'json/pure'
 require 'sensu-plugin/check/cli'
 require 'fileutils'
 require 'yaml'

--- a/files/cache_instance_list.rb
+++ b/files/cache_instance_list.rb
@@ -4,6 +4,7 @@ require 'fog'
 require 'json/pure'
 require 'sensu-plugin/check/cli'
 require 'fileutils'
+require 'yaml'
 
 class Instance_list < Sensu::Plugin::Check::CLI
 
@@ -11,19 +12,25 @@ class Instance_list < Sensu::Plugin::Check::CLI
     :short => '-a AWS_ACCESS_KEY',
     :long => '--aws-access-key AWS_ACCESS_KEY',
     :description => "AWS Access Key. Either set ENV['AWS_ACCESS_KEY_ID'] or provide it as an option",
-    :required => true
+    :required => false
 
   option :aws_secret_access_key,
     :short => '-k AWS_SECRET_ACCESS_KEY',
     :long => '--aws-secret-access-key AWS_SECRET_ACCESS_KEY',
     :description => "AWS Secret Access Key. Either set ENV['AWS_SECRET_ACCESS_KEY'] or provide it as an option",
-    :required => true
+    :required => false
 
   option :aws_region,
     :short => '-r AWS_REGION',
     :long => '--aws-region REGION',
     :description => "AWS Region (such as eu-west-1).",
     :default => 'us-east-1'
+
+  option :credential_file,
+    :short => '-f credential_file',
+    :long => '--credential-file credential_file',
+    :description => 'fog credential file',
+    :required => false
 
   def write_instance_cache(instance_list)
     bail if instance_list.nil?
@@ -33,12 +40,14 @@ class Instance_list < Sensu::Plugin::Check::CLI
 
   def ec2
     @ec2 ||= begin
-      Fog::Compute.new({
-        :provider => 'AWS',
-        :aws_access_key_id      => config[:aws_access_key],
-        :aws_secret_access_key  => config[:aws_secret_access_key],
-        :region                 => config[:aws_region]
-      })
+      opts = { :provider => 'AWS', :region => config[:aws_region] }
+      if config[:credential_file]
+        Fog.credentials_path = config[:credential_file]
+      elsif config[:aws_access_key] && config[:aws_secret_access_key]
+        opts.merge! :aws_access_key_id      => config[:aws_access_key],
+                    :aws_secret_access_key  => config[:aws_secret_access_key]
+      end
+      Fog::Compute.new opts
     end
   end
 

--- a/manifests/aws_prune.pp
+++ b/manifests/aws_prune.pp
@@ -53,6 +53,7 @@ class sensu_handlers::aws_prune inherits sensu_handlers {
      tip         => 'talk to kwa',
      command     => "/usr/lib/nagios/plugins/check_file_age /var/cache/instance_list.json -w 1800 -c 3600",
      page        => false,
+     ticket      => true,
    }
  }
 

--- a/manifests/aws_prune.pp
+++ b/manifests/aws_prune.pp
@@ -43,7 +43,7 @@ class sensu_handlers::aws_prune inherits sensu_handlers {
     cron::d { 'cache_instance_list':
       minute  => '*',
       user    => 'root',
-      command => "/etc/sensu/plugins/cache_instance_list.rb -r ${region} -f /etc/sensu/cache_instance_list_creds.yaml",
+      command => "/opt/puppet-omnibus/embedded/bin/ruby /etc/sensu/plugins/cache_instance_list.rb -r ${region} -f /etc/sensu/cache_instance_list_creds.yaml",
     } ->
     monitoring_check { 'cache_instance_list-staleness':
      check_every => '10m',


### PR DESCRIPTION
Newer versions of fog pull in fog-json which will take care of figuring out the best way how to work with json. This lets it do its job, no need to hardcode json/pure.