### PR TITLE
Time in irc messages

### DIFF
--- a/files/nodebot.rb
+++ b/files/nodebot.rb
@@ -42,7 +42,8 @@ class Nodebot < BaseHandler
     # Max irc line length is theoretically 512 from the RFC, but after the
     # color, line breaks etc it comes out to ~ 419 for us? Just truncate
     # to 415 to be safe
-    pre = "[sensu] #{color} #{status} - "
+    now = Time.now
+    pre = "[sensu] #{now.hour}:#{now.min}:#{now.sec} #{color} #{status} - "
     "#{pre}#{description(415 - pre.length)}"
   end
 

--- a/files/nodebot.rb
+++ b/files/nodebot.rb
@@ -40,11 +40,11 @@ class Nodebot < BaseHandler
     end
 
     # Max irc line length is theoretically 512 from the RFC, but after the
-    # color, line breaks etc it comes out to ~ 419 for us? Just truncate
-    # to 415 to be safe
+    # color, line breaks etc it comes out to ~ 411 for us? Just truncate
+    # to 405 to be safe
     now = Time.now
     pre = "[sensu] #{now.hour}:#{now.min}:#{now.sec} #{color} #{status} - "
-    "#{pre}#{description(415 - pre.length)}"
+    "#{pre}#{description(405 - pre.length)}"
   end
 
   def handle


### PR DESCRIPTION
This will help us tell when irc is lagging.

I got confused today when Sensu broke in IAD1, and I was looking at old irc notifications (after things had been fixed) that still had failures.

Having a timestamp in the messages will let you compare and work out if things are lagged.

cc @yeled 