### PR TITLE
repoint apt in fixtures to proper upstream

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,5 +9,5 @@ fixtures:
         ref: 288de5099814645afce643013b0951d3782ef328
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
     apt:
-        repo: 'git://github.com/somic/puppetlabs-apt.git'
-        ref: ee51cf6929e1c51857ae43e720a32145df780d70
+        repo: 'git://github.com/puppetlabs/puppetlabs-apt.git'
+        ref: 2.1.0

--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -1,6 +1,7 @@
 Package {
   provider => 'apt'
 }
+include apt
 include sensu
 
 package { 'rubygem-sensu-plugin': }


### PR DESCRIPTION
I will be upgrading our puppetlabs-apt to 2.1.0 soon (hopefully). In preparation for this, as suggested by @bobtfish on an internal ticket, I am fixing fixtures here to point to proper upstream.

I think it's ok to merge this PR now, even when we are still on an older puppetlabs-apt in our tree.