### PR TITLE
Truncate long descriptions for the Pagerduty handler, and log failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,11 @@ sensu_handlers::teams:
 
 You can manually invoke these handlers in order to test them, ensuring that (for example) 
 a JIRA ticket is correctly raised. Simply pipe the Sensu alert in JSON into one of the 
-handlers, and it should parse it as if it were a fresh alert:
+handlers, and it should parse it as if it were a fresh alert.
 
 ```
 $ grep 'failed' /var/log/sensu/sensu-server.log  | tail -n 1 | jq .event > last_failed_event.json
-$ cat last_failed_event | jira.rb
+$ cat last_failed_event | sudo ruby jira.rb
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ handlers, and it should parse it as if it were a fresh alert.
 
 ```
 $ grep 'failed' /var/log/sensu/sensu-server.log  | tail -n 1 | jq .event > last_failed_event.json
-$ cat last_failed_event | sudo ruby jira.rb
+$ cat last_failed_event | sudo -u sensu ruby jira.rb
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ sensu_handlers::teams:
 * *`notification_email: 'operations@localhost'`* - If set, the handler will send emails for every event to this address. If ommited it will send no emails. You can send the email to multiple destinations by using comma separated list (like any email client)
 * *`project: OPS`* - Used by the JIRA handler. If a event comes in that has `ticket=>true`, the jira handler will open a ticket on this project. There no default for this parameter. Special considerations have to be made for the JIRA project to enable auto-opening and auto-closing of tickets, see the docs on the jira handler.
 
+
+### Manually Invoking These Handlers
+
+You can manually invoke these handlers in order to test them, ensuring that (for example) 
+a JIRA ticket is correctly raised. Simply pipe the Sensu alert in JSON into one of the 
+handlers, and it should parse it as if it were a fresh alert:
+
+```
+$ grep 'failed' /var/log/sensu/sensu-server.log  | tail -n 1 | jq .event > last_failed_event.json
+$ cat last_failed_event | jira.rb
+```
+
+
 ### Support
 
 Please open a github issue for support.

--- a/files/pagerduty.rb
+++ b/files/pagerduty.rb
@@ -24,11 +24,11 @@ class Pagerduty < BaseHandler
       :description  => description(1024),
       :details      => full_description_hash
     )['status']
-    if response != 'success'
+    if response == 'success'
+      true
+    else
       log response
       false
-    else
-      true
     end
   end
 

--- a/files/pagerduty.rb
+++ b/files/pagerduty.rb
@@ -18,12 +18,18 @@ class Pagerduty < BaseHandler
   def trigger_incident
     return false unless api_key
     require 'redphone/pagerduty'
-    Redphone::Pagerduty.trigger_incident(
+    response = Redphone::Pagerduty.trigger_incident(
       :service_key  => api_key,
       :incident_key => incident_key,
-      :description  => description,
+      :description  => description(1024),
       :details      => full_description_hash
-    )['status'] == 'success'
+    )['status']
+    if response != 'success'
+      log response
+      false
+    else
+      true
+    end
   end
 
   def resolve_incident


### PR DESCRIPTION
This will cap a description to 1024 characters, which is the maximum length the Pagerduty handler supports. It will log any problems in raising the alert.

Manually tested this by creating an alert with a sufficiently long description; it paged and truncated in PD.