### PR TITLE
Try to limit the pagerduty description field further to make it less …

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -69,7 +69,7 @@ class BaseHandler < Sensu::Handler
 
   def description(maxlen=0)
     description = @event['check']['notification']
-    description ||= [@event['client']['name'], @event['check']['name'], @event['check']['output']].join(' : ')
+    description ||= [@event['client']['name'], @event['check']['name'], uncolorize(@event['check']['output'])].join(' : ')
     if event_is_critical? or event_is_warning?
       toadd = ""
       if tip

--- a/files/pagerduty.rb
+++ b/files/pagerduty.rb
@@ -21,7 +21,7 @@ class Pagerduty < BaseHandler
     response = Redphone::Pagerduty.trigger_incident(
       :service_key  => api_key,
       :incident_key => incident_key,
-      :description  => description(1024),
+      :description  => description(140),
       :details      => full_description_hash
     )['status']
     if response == 'success'


### PR DESCRIPTION
…messy

@vulpine  before we were doing 1024, but with a long output from the check, this makes it super messy in PD. I think for the description field, which is what you see in the main interface (before you click the info button), should be short, and 140 seems like a good twitter-size number?