### PR TITLE
Append timestamp to sensu IRC notifications

### DIFF
--- a/files/nodebot.rb
+++ b/files/nodebot.rb
@@ -42,8 +42,10 @@ class Nodebot < BaseHandler
     # Max irc line length is theoretically 512 from the RFC, but after the
     # color, line breaks etc it comes out to ~ 419 for us? Just truncate
     # to 415 to be safe
+    timestamp = Time.now().strftime("%F %T")
     pre = "[sensu] #{color} #{status} - "
-    "#{pre}#{description(415 - pre.length)}"
+    post = " (#{timestamp})"
+    "#{pre}#{description(415 - pre.length - post.length)}#{post}"
   end
 
   def handle

--- a/spec/functions/nodebot_spec.rb
+++ b/spec/functions/nodebot_spec.rb
@@ -38,6 +38,8 @@ describe Nodebot do
     end
     it { expect(subject.pages_irc_channel).to eql('#criticals') }
     it { expect(subject.channels).to eql(['criticals']) }
+    timestamp_regex = / \(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\)$/
+    it { expect(subject.message).to match(timestamp_regex) }
   end
   context "should page default team pages channel when not setup" do
     before(:each) do


### PR DESCRIPTION
Right now there's no timestamp printed with Sensu messages into IRC. When IRC backs up, it helps to have the timestamp for reference.