### PR TITLE
Make the pagerduty handler create events whenever sensu creates events.

### DIFF
--- a/files/pagerduty.rb
+++ b/files/pagerduty.rb
@@ -47,27 +47,21 @@ class Pagerduty < BaseHandler
       return
     end
     begin
-      action = case @event['check']['status'].to_i
-        when 2
-          'trigger'
-        when 0,1
-        'resolve'
-      end
       response = timeout_and_retry do
-        case @event['check']['status'].to_i
-        when 2
+        case @event['action']
+        when 'create'
           trigger_incident
-        when 0,1
+        when 'resolve'
           resolve_incident
         end
       end
       if response
-        log 'pagerduty -- ' + action.capitalize + 'd incident -- ' + incident_key
+        log 'pagerduty -- ' + @event['action'].capitalize + 'd incident -- ' + incident_key
       else
-        log 'pagerduty -- failed to ' + action + ' incident -- ' + incident_key
+        log 'pagerduty -- failed to ' + @event['action'] + ' incident -- ' + incident_key
       end
     rescue Timeout::Error
-      log 'pagerduty -- timed out while attempting to ' + action + ' an incident -- ' + incident_key
+      log 'pagerduty -- timed out while attempting to ' + @event['action'] + ' an incident -- ' + incident_key
     end
   end
 end


### PR DESCRIPTION
Primary: tdoran

We currently try to never send warnings to PD.

However, this causes some bugs/oddities because our filtering logic considers 1,2 to be creation events and 0 to be resolve, where as the PD handler consides them 2 to be creation events and 0,1 to be resolve events.

This causes some "resolve events" to never make it through, I think, and generally seems weird.
It also causes unnecessary spam to the PD api as we spam it with "resolves" constantly whenever we have a warning going off.

I think we should give up on this and make our PD handler fit more in line with what sensu is actually doing. (making the create and resolve events align)

If we don't want warnings to go to PD, then we shouldn't be making monitoring checks that are set to page that have bogus warning levels that we don't actually care about?