### PR TITLE
fix filter_repeated': divided by 0

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -173,7 +173,10 @@ BODY
       interval      = @event['check']['interval'].to_i || 0
     end
     alert_after   = @event['check']['alert_after'].to_i || 0
-    realert_every = @event['check']['realert_every'].to_i || 1
+
+    # nil.to_i == 0
+    # 0 || 1   == 0
+    realert_every = ( @event['check']['realert_every'] || 1 ).to_i 
 
     initial_failing_occurrences = interval > 0 ? (alert_after / interval) : 0
     number_of_failed_attempts = @event['occurrences'] - initial_failing_occurrences

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -342,6 +342,17 @@ describe BaseHandler do
         expect(subject.filter_repeated).to eql(nil)
       end
     end
+    context "when realert_every is not set" do
+      it "treats realert_every as 1" do
+        subject.event['occurrences'] = 6
+        subject.event['check']['interval'] = 20
+        subject.event['check']['alert_after'] = 60
+        subject.event['check'].delete('realert_every')
+        subject.event['action'] = 'create'
+        expect(subject).not_to receive(:bail)
+        expect(subject.filter_repeated).to eql(nil)
+      end
+    end
   end #End filter repeated
 
   context "With display name tag" do


### PR DESCRIPTION
if realert_every is somehow not set it caued a divide by zero error.
because `nil.to_i` is `0` and  `0 || 1` is `0`.  [ruby is not shell]