### PR TITLE
quiet mailer spec

### DIFF
--- a/files/mailer.rb
+++ b/files/mailer.rb
@@ -104,10 +104,10 @@ class Mailer < BaseHandler
           body    body
         end
 
-        puts 'mail -- sent alert for ' + short_name + ' to ' + mail_to.to_s
+        log 'mail -- sent alert for ' + short_name + ' to ' + mail_to.to_s
       end
     rescue Timeout::Error
-      puts 'mail -- timed out while attempting to ' + @event['action'] + ' an incident -- ' + short_name
+      log 'mail -- timed out while attempting to ' + @event['action'] + ' an incident -- ' + short_name
     end
   end
 

--- a/spec/functions/mailer_spec.rb
+++ b/spec/functions/mailer_spec.rb
@@ -46,6 +46,7 @@ describe Mailer do
     subject.event['check']['name'] = 'fake_alert'
     subject.event['client']['name'] = 'fake_client'
     Mail.stub(:deliver).and_return(true)
+    subject.stub(:log).and_return(nil) # quiet specs
     subject.handle
   end
 


### PR DESCRIPTION
spec prints out:

  "mail -- sent alert for fake_client/fake_alert to test@email"

which messes up the pretty dots from rspec --format progress
make it overridable and override it.