### PR TITLE
Removing the dependency on the sensu-community-plugins package

### DIFF
--- a/manifests/graphite.pp
+++ b/manifests/graphite.pp
@@ -22,7 +22,6 @@ class sensu_handlers::graphite inherits sensu_handlers {
       group   => root,
       mode    => '0444',
       content => inline_template('<%= require "json"; JSON.generate @graphite_data %>'),
-      require => Package['sensu-community-plugins'],
   }
 
   sensu::handler { 'graphite':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 #
 # [*teams*]
 #  A hash configuring the different desired configuration for the default
-#  handler behavior given a particular team. See the main README.md for 
+#  handler behavior given a particular team. See the main README.md for
 #  examples. This parameter is required.
 #
 # [*package_ensure*]
@@ -23,7 +23,7 @@
 # [*jira_username*]
 # [*jira_password*]
 # [*jira_site*]
-#  If you are using the JIRA handler, it needs basic auth to work. 
+#  If you are using the JIRA handler, it needs basic auth to work.
 #  Fill in the credentials and url to your local JIRA instance.
 #
 # [*include_graphite*]
@@ -55,8 +55,6 @@ class sensu_handlers(
   validate_hash($teams)
   validate_bool($include_graphite, $include_aws_prune)
 
-  ensure_packages(['sensu-community-plugins'])
-
   file { '/etc/sensu/handlers/base.rb':
     source => 'puppet:///modules/sensu_handlers/base.rb',
     mode   => '0644',
@@ -86,4 +84,3 @@ class sensu_handlers(
     include sensu_handlers::aws_prune
   }
 }
-

--- a/manifests/nodebot.pp
+++ b/manifests/nodebot.pp
@@ -10,8 +10,7 @@ class sensu_handlers::nodebot inherits sensu_handlers {
     source  => 'puppet:///modules/sensu_handlers/nodebot.rb',
     config  => {
       teams => $teams,
-    },
-    require => Package['sensu-community-plugins'];
+    }
   }
 
 }

--- a/manifests/opsgenie.pp
+++ b/manifests/opsgenie.pp
@@ -9,8 +9,7 @@ class sensu_handlers::opsgenie inherits sensu_handlers {
     source  => 'puppet:///modules/sensu_handlers/opsgenie.rb',
     config  => {
       teams => $teams,
-    },
-    require => [ Package['sensu-community-plugins'] ],
+    }
   }
   # If we are going to send pagerduty alerts, we need to be sure it actually is up
   monitoring_check { 'check_opsgenie':

--- a/manifests/pagerduty.pp
+++ b/manifests/pagerduty.pp
@@ -11,7 +11,7 @@ class sensu_handlers::pagerduty inherits sensu_handlers {
     config  => {
       teams => $teams,
     },
-    require => [ Package['sensu-community-plugins'], Package['rubygem-redphone'] ],
+    require => [ Package['rubygem-redphone'] ],
   }
   # If we are going to send pagerduty alerts, we need to be sure it actually is up
   monitoring_check { 'check_pagerduty':


### PR DESCRIPTION
The sensu-community-plugins package has been deprecreated in favor of
seperate gems for each plugin. This commit removes that explict package
dependency.