### PR TITLE
Add support for tags as labels

### DIFF
--- a/files/jira.rb
+++ b/files/jira.rb
@@ -4,6 +4,12 @@ require "#{File.dirname(__FILE__)}/base"
 
 class Jira < BaseHandler
 
+  def build_labels
+    [ "SENSU_#{@event['client']['name']}",
+      "SENSU_#{@event['check']['name']}",
+      "SENSU", *@event['check']['tags'] ].uniq
+  end
+
   def create_issue(summary, full_description, project)
     begin
       require 'jira'
@@ -25,11 +31,7 @@ class Jira < BaseHandler
             "description"=> full_description,
             "project"=> { "id"=>project_id },
             "issuetype"=> {"id"=>1},
-            "labels" => [
-               "SENSU_#{@event['client']['name']}",
-               "SENSU_#{@event['check']['name']}",
-               "SENSU"
-            ]
+            "labels" => build_labels
           }
         }
         issue.save(issue_json)

--- a/spec/functions/jira_spec.rb
+++ b/spec/functions/jira_spec.rb
@@ -81,6 +81,14 @@ describe Jira do
       subject.handle
     end
 
+    it "Tags exists in the Event" do
+      subject.event['check']['status'] = 2
+      subject.event['check']['tags'] = ["some_tag"]
+      expect(subject.build_labels).to match_array(["SENSU", "SENSU_mycoolcheck", "SENSU_some.client", "some_tag"])
+      expect(subject).to receive(:create_issue).and_return(true)
+      subject.handle
+    end
+
   end
 
 end


### PR DESCRIPTION
Refactored as per @keymone's suggestions.

This will use the arbitrary tags introduced in https://github.com/Yelp/puppet-monitoring_check/commit/f63c963ef4d46d7c6805224d6a75f053dd5cc2bb

We might want to merge this into a another branch and test it before merging this.