### PR TITLE
flexibly manage handler dependencies for pagerduty and mailer

### DIFF
--- a/manifests/deps.pp
+++ b/manifests/deps.pp
@@ -1,0 +1,9 @@
+define sensu_handlers::deps ($dependencies) {
+  if $dependencies {
+    create_resources(
+      'package',
+      $dependencies,
+      {before => Sensu::Handler[$title]}
+    )
+  }
+}

--- a/manifests/mailer.pp
+++ b/manifests/mailer.pp
@@ -2,13 +2,15 @@
 #
 # Sensu handler to send emails.
 #
-class sensu_handlers::mailer inherits sensu_handlers {
+class sensu_handlers::mailer (
+  $dependencies = {
+    'nagios-plugins-basic' => {},
+    'mail'                 => { 'provider' => 'gem' }
+  }
+) inherits sensu_handlers {
 
-  ensure_packages(['nagios-plugins-basic'])
+  sensu_handlers::deps {'mailer': dependencies => $dependencies }
 
-  package { 'rubygem-mail':
-    ensure => '2.5.4',
-  } ->
   sensu::handler { 'mailer':
     type    => 'pipe',
     source  => 'puppet:///modules/sensu_handlers/mailer.rb',
@@ -16,6 +18,7 @@ class sensu_handlers::mailer inherits sensu_handlers {
       teams => $teams,
     }
   }
+
   monitoring_check { 'check_smtp_for_sensu_handler':
     check_every   => '5m',
     alert_after   => '10m',
@@ -24,7 +27,6 @@ class sensu_handlers::mailer inherits sensu_handlers {
     team          => 'operations',
     command       => '/usr/lib/nagios/plugins/check_smtp -H localhost',
     runbook       => 'y/?',
-    require       => [ Package['nagios-plugins-basic'] ],
   }
 
 }

--- a/manifests/pagerduty.pp
+++ b/manifests/pagerduty.pp
@@ -2,16 +2,22 @@
 #
 # Sensu handler for communicating with Pagerduty
 #
-class sensu_handlers::pagerduty inherits sensu_handlers {
+class sensu_handlers::pagerduty (
+  $pagerduty_package       = 'redphone',
+  $pagerduty_package_opts  = { 'provider' => 'gem' }
+) inherits sensu_handlers {
 
-  ensure_packages(['rubygem-redphone'])
+  if $pagerduty_package {
+    ensure_resource('package', $pagerduty_package, $pagerduty_package_opts)
+    Package[$pagerduty_package] -> Sensu::Handler['pagerduty']
+  }
+
   sensu::handler { 'pagerduty':
     type    => 'pipe',
     source  => 'puppet:///modules/sensu_handlers/pagerduty.rb',
     config  => {
       teams => $teams,
-    },
-    require => [ Package['rubygem-redphone'] ],
+    }
   }
   # If we are going to send pagerduty alerts, we need to be sure it actually is up
   monitoring_check { 'check_pagerduty':

--- a/manifests/pagerduty.pp
+++ b/manifests/pagerduty.pp
@@ -3,13 +3,17 @@
 # Sensu handler for communicating with Pagerduty
 #
 class sensu_handlers::pagerduty (
-  $pagerduty_package       = 'redphone',
-  $pagerduty_package_opts  = { 'provider' => 'gem' }
+  $dependencies = {
+    'redphone' => { 'provider' => 'gem' }
+  }
 ) inherits sensu_handlers {
 
-  if $pagerduty_package {
-    ensure_resource('package', $pagerduty_package, $pagerduty_package_opts)
-    Package[$pagerduty_package] -> Sensu::Handler['pagerduty']
+  if $dependencies {
+    create_resources(
+      'package',
+      $dependencies,
+      {before => Sensu::Handler['pagerduty']}
+    )
   }
 
   sensu::handler { 'pagerduty':
@@ -19,6 +23,7 @@ class sensu_handlers::pagerduty (
       teams => $teams,
     }
   }
+
   # If we are going to send pagerduty alerts, we need to be sure it actually is up
   monitoring_check { 'check_pagerduty':
     check_every => '60m',

--- a/manifests/pagerduty.pp
+++ b/manifests/pagerduty.pp
@@ -8,13 +8,7 @@ class sensu_handlers::pagerduty (
   }
 ) inherits sensu_handlers {
 
-  if $dependencies {
-    create_resources(
-      'package',
-      $dependencies,
-      {before => Sensu::Handler['pagerduty']}
-    )
-  }
+  sensu_handlers::deps {'pagerduty': dependencies => $dependencies }
 
   sensu::handler { 'pagerduty':
     type    => 'pipe',


### PR DESCRIPTION
unless you've packaged it yourself there's no rubygems-redphone debian
package around.

make it possible for other to meet this dependency some other way.

in the interim default to installing via gem.