### PR TITLE
add filter for jira handler

### DIFF
--- a/manifests/jira.pp
+++ b/manifests/jira.pp
@@ -5,6 +5,9 @@
 class sensu_handlers::jira inherits sensu_handlers {
 
   package { 'rubygem-jira-ruby': ensure => '0.1.9' } ->
+  sensu::filter { 'ticket_filter':
+    attributes => { 'check' => { 'ticket' => true } },
+  } ->
   sensu::handler { 'jira':
     type    => 'pipe',
     source  => 'puppet:///modules/sensu_handlers/jira.rb',
@@ -14,6 +17,7 @@ class sensu_handlers::jira inherits sensu_handlers {
       password => $jira_password,
       site     => $jira_site,
     },
+    filters => [ 'ticket_filter' ],
   }
   if $::lsbdistcodename == 'Lucid' {
     # So sorry for the httprb monkeypatch. It is Debian bug 564168 that took


### PR DESCRIPTION
I picked jira handler to start with because it's going to be less impact if it breaks or doesn't work right for some unexpected reason. Once this is merged and rolled out, we will do pagerduty handler in exactly the same way.

Please see internal OPS-1863 for rollout planning and discussion.