### PR TITLE
flexibly manage dependencies with merged overrides

### DIFF
--- a/lib/puppet/parser/functions/merge_resources.rb
+++ b/lib/puppet/parser/functions/merge_resources.rb
@@ -1,0 +1,28 @@
+module Puppet::Parser::Functions
+  newfunction(:merge_resources, :type => :rvalue) do |args|
+    if args.length != 2
+      raise Puppet::Error,
+        "wrong number of args expected 2 resource hashes"
+    end
+
+    args.each do |arg|
+      unless arg.kind_of? Hash
+        raise "expected resource hash. got #{arg}"
+      end
+    end
+
+    overrides = args[0]
+    results   = args[1].dup
+
+    overrides.each do |k,v|
+      if v == :undef
+        results.delete(k)
+      else
+        results[k] ||= {}
+        results[k].merge!(v)
+      end
+    end
+
+    results
+  end
+end

--- a/manifests/aws_prune.pp
+++ b/manifests/aws_prune.pp
@@ -3,18 +3,36 @@
 # Sensu handler for removing clients from sensu if they are not in the AWS
 # API.
 #
-class sensu_handlers::aws_prune inherits sensu_handlers {
+class sensu_handlers::aws_prune (
+  $dependencies = {},
+) inherits sensu_handlers {
 
-  # Only EC2 Sensu servers need to worry about querying the AWS api to know if 
+
+
+  # Only EC2 Sensu servers need to worry about querying the AWS api to know if
   # They need to prune or not
   if str2bool($::is_ec2) == true {
+
+    if $dependencies {
+
+      $defaults = {
+        'fog' => { provider => $gem_provider },
+        'unf' => { provider => $gem_provider },
+      }
+
+      create_resources(
+        package,
+        merge_resources($dependencies, $defaults),
+        { before => Sensu::Handler['aws_prune'] }
+      )
+
+    }
 
     $access_key = hiera('sensu::aws_key')
     $secret_key = hiera('sensu::aws_secret')
 
     validate_string($access_key, $secret_key, $region)
 
-    ensure_packages(['rubygem-fog', 'rubygem-unf'])
     $aws_config_hash =  {
       access_key => $access_key,
       secret_key => $secret_key,
@@ -25,14 +43,12 @@ class sensu_handlers::aws_prune inherits sensu_handlers {
       type    => 'pipe',
       source  => 'puppet:///modules/sensu_handlers/aws_prune.rb',
       config  => $aws_config_hash,
-      require => [ Package['rubygem-fog'], Package['rubygem-sensu-plugin'], Package['rubygem-unf'] ],
     }
     file { '/etc/sensu/plugins/cache_instance_list.rb':
       owner   => 'root',
       group   => 'root',
       mode    => '0500',
       source  => 'puppet:///modules/sensu_handlers/cache_instance_list.rb',
-      require => [ Package['rubygem-fog'], Package['rubygem-sensu-plugin'], Package['rubygem-unf'] ],
     } ->
     file { '/etc/sensu/cache_instance_list_creds.yaml':
       owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@
 # [*region*]
 #  The aws region so the aws_prune handler knows wich API endpoint to query
 #
+# [*use_embeded_ruby*]
+#  use provider => sensu_gem for any gem packages
 class sensu_handlers(
   $teams,
   $package_ensure        = 'latest',
@@ -50,10 +52,16 @@ class sensu_handlers(
   $region                = $::datacenter,
   $datacenter            = $::datacenter,
   $dashboard_link        = "https://sensu.${::domain}",
+  $use_embedded_ruby     = false,
 ) {
 
   validate_hash($teams)
   validate_bool($include_graphite, $include_aws_prune)
+
+  $gem_provider = $use_embedded_ruby ? {
+    true    => 'sensu_gem',
+    default => 'gem'
+  }
 
   file { '/etc/sensu/handlers/base.rb':
     source => 'puppet:///modules/sensu_handlers/base.rb',

--- a/manifests/jira.pp
+++ b/manifests/jira.pp
@@ -2,9 +2,21 @@
 #
 # Sensu handler to open and close Jira tickets for you.
 #
-class sensu_handlers::jira inherits sensu_handlers {
+class sensu_handlers::jira (
+  $dependencies = {}
+) inherits sensu_handlers {
 
-  package { 'rubygem-jira-ruby': ensure => '0.1.9' } ->
+  if $dependencies {
+    $defaults = {
+      'jira-ruby' => { ensure => '0.1.9' }
+    }
+    create_resources(
+      'package',
+      merge_resources($dependencies, $defaults),
+      { before => Sensu::Handler['jira'] }
+    )
+  }
+
   sensu::filter { 'ticket_filter':
     attributes => { 'check' => { 'ticket' => true } },
   } ->

--- a/manifests/pagerduty.pp
+++ b/manifests/pagerduty.pp
@@ -2,16 +2,32 @@
 #
 # Sensu handler for communicating with Pagerduty
 #
-class sensu_handlers::pagerduty inherits sensu_handlers {
+class sensu_handlers::pagerduty (
+  $dependencies = {}
+) inherits sensu_handlers {
 
-  ensure_packages(['rubygem-redphone'])
+  if $dependencies {
+
+    $defaults = {
+      'redphone' => {
+        provider => $gem_provider,
+      }
+    }
+
+    create_resources(
+      package,
+      merge_resources($dependencies, $defaults),
+      { before => Sensu::Handler['pagerduty'] }
+    )
+
+  }
+
   sensu::handler { 'pagerduty':
     type    => 'pipe',
     source  => 'puppet:///modules/sensu_handlers/pagerduty.rb',
     config  => {
       teams => $teams,
     },
-    require => [ Package['rubygem-redphone'] ],
   }
   # If we are going to send pagerduty alerts, we need to be sure it actually is up
   monitoring_check { 'check_pagerduty':

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,30 +2,63 @@ require 'spec_helper'
 
 describe 'sensu_handlers', :type => :class do
 
-
   let(:facts) {{
     :osfamily => 'Debian',
     :lsbdistid => 'debian',
   }}
 
-  context 'By default, it needs teams to be provided' do
-    it { should_not compile }
+  let(:teams) {{
+    'operations' => {}
+  }}
+
+  describe "teams" do
+    context 'By default, it needs teams to be provided' do
+      it { should_not compile }
+    end
+
+    context 'With teams' do
+      let(:params) {{
+        :jira_username => 'foo',
+        :jira_password => 'bar',
+        :jira_site => 'https://jira.mycompany.com',
+        :teams     => teams
+      }}
+      let(:hiera_data) {{
+        :'sensu_handlers::teams' => teams
+      }}
+      it { should compile }
+    end
   end
 
-  context 'With teams' do
-    let(:teams) {{
-      'operations' => {}
-    }}
+  describe 'use_embedded_ruby' do
+    let(:pre_condition) do
+      <<-EOM
+        class sensu_handlers::test () inherits sensu_handlers {
+          package{'foo': provider => $gem_provider }
+        }
+      EOM
+    end
+
     let(:params) {{
-      :jira_username => 'foo',
-      :jira_password => 'bar',
-      :jira_site => 'https://jira.mycompany.com',
-      :teams     => teams
+      :default_handler_array =>  ['test'],
+      :use_embedded_ruby     => use_embedded_ruby,
+      :teams                 => teams
     }}
-    let(:hiera_data) {{
-      :'sensu_handlers::teams' => teams
-    }}
-    it { should compile }
+
+    context "when true" do
+      let(:use_embedded_ruby)  { true }
+      it "sets $gem_provider to sensu_gem" do
+        should create_package(:foo).with_provider('sensu_gem')
+      end
+    end
+
+    context "when false" do
+      let(:use_embedded_ruby)  { false }
+      it "sets $gem_provider to gem" do
+        should create_package(:foo).with_provider('gem')
+      end
+    end
+
   end
 
 end

--- a/spec/classes/mailer_spec.rb
+++ b/spec/classes/mailer_spec.rb
@@ -1,0 +1,47 @@
+describe "sensu_handlers::mailer" do
+  let(:facts) {{
+    :osfamily => 'Debian',
+    :lsbdistid => 'debian',
+  }}
+  let(:teams) {{
+    'operations' => {}
+  }}
+  let(:hiera_data) {{
+    'sensu_handlers::teams' => teams
+  }}
+
+  it { should compile }
+
+  describe "dependencies param" do
+    context "when left to default" do
+      it { should contain_package('nagios-plugins-basic')      }
+      it { should contain_package('mail').with_provider('gem') }
+    end
+    context "when false" do
+      let(:params) {{ :dependencies => false }}
+      it { should_not contain_package('nagios-plugins-basic')      }
+      it { should_not contain_package('mail').with_provider('gem') }
+    end
+
+    context "with knockouts" do
+      context "with mail set to undef" do
+        # hack enable next hack
+        let(:params)    { true }
+        # next hack, rspec-puppet #param_str can't create param undef
+        let(:param_str) { 'dependencies => { mail => undef }' }
+
+        it { should     contain_package('nagios-plugins-basic')      }
+        it { should_not contain_package('mail').with_provider('gem') }
+      end
+    end
+
+    context "with package level overrides" do
+      let(:params)    { true }
+      let(:param_str) { 'dependencies => { mail => { provider => "foo" }}' }
+
+      it { should contain_package('nagios-plugins-basic')      }
+      it { should contain_package('mail').with_provider('foo') }
+    end
+
+  end
+end

--- a/spec/functions/merge_resources_spec.rb
+++ b/spec/functions/merge_resources_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+describe 'merge_resources', :type => :function do
+  # these facts are required because the fixtures top scope
+  # manifest includes the apt class
+  let(:facts) {{
+    :osfamily => 'Debian',
+    :lsbdistid => 'debian',
+  }}
+
+  it "requires two arguments" do
+    should run.with_params() \
+      .and_raise_error(/wrong number of args/)
+
+    should run.with_params(:one) \
+      .and_raise_error(/wrong number of args/)
+
+    should run.with_params(:one,:two,:three) \
+      .and_raise_error(/wrong number of args/)
+
+    should run.with_params({},{})
+  end
+
+  it "requires two hashes" do
+    should run.with_params(:one,:two) \
+      .and_raise_error(/expected resource hash/)
+
+    should run.with_params({}, :two) \
+      .and_raise_error(/expected resource hash/)
+
+    should run.with_params(:one,{}) \
+      .and_raise_error(/expected resource hash/)
+
+    should run.with_params({},{})
+  end
+
+  let(:defaults) {{
+    'title1' => {
+      'param1' => 'value1',
+      'param2' => 'value2'
+    },
+    'title2' => { 'param' => 'value2' }
+  }}
+
+  context "with matching key in override" do
+    let(:override) {{
+      'title1' => {
+        'param1' => 'value3',
+        'thing'  => 'value3'
+      }
+    }}
+
+    it "merges those two values" do
+      should run.with_params(override,defaults) \
+        .and_return({
+          'title1' => {
+            'param1' => 'value3',
+            'param2' => 'value2',
+            'thing'  => 'value3'
+          },
+          'title2' => { 'param' => 'value2' }
+        })
+    end
+  end
+
+  context "non matching key in overrides" do
+    let(:override) {{
+      'title3' => { 'thing' => 'value3' }
+    }}
+    it "is merged in with results" do
+      should run.with_params(override,defaults) \
+        .and_return({
+          'title1' => {
+            'param1' => 'value1',
+            'param2' => 'value2'
+          },
+          'title2' => { 'param' => 'value2' },
+          'title3' => { 'thing' => 'value3' }
+        })
+    end
+  end
+
+  context "key in overrides who's value is undef" do
+    let(:override) {{
+      'title3' => :undef,
+      'title1' => :undef,
+    }}
+    it "removes that key from the results" do
+      should run.with_params(override,defaults) \
+        .and_return({
+          'title2' => { 'param' => 'value2' }
+        })
+    end
+  end
+
+  context "undef from puppet manifests" do
+    # flip back into catalog as subject mode
+    let(:subject) { lambda { catalogue } }
+    let(:pre_condition) do
+      <<-EOM
+        create_resources(file, merge_resources({
+          '/extra'    => { owner => 'extra' },
+          '/knockout' => undef
+        }, {
+          '/knockout' => { owner => 'knockout' },
+          '/default'  => { owner => 'default' },
+        }))
+      EOM
+    end
+    it { should     contain_file('/default')  }
+    it { should     contain_file('/extra')    }
+    it { should_not contain_file('/knockout') }
+  end
+
+end


### PR DESCRIPTION
Alternate to #60 

support a dependencies argument. 

when false: disables dependency management.

when set to an array of resource defs sutible for create_resources: they will be merged into the defaults allowing package level param overrides.  for example `{ package_title => { param1 => 'override' }  }`

also allows for "knocking out" a single  dependency rather than all by using `{ package_title => undef }`