### PR TITLE
flexibly manage package deps #4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@
 # [*region*]
 #  The aws region so the aws_prune handler knows wich API endpoint to query
 #
+# [*use_embeded_ruby*]
+#  use provider => sensu_gem for any gem packages
 class sensu_handlers(
   $teams,
   $package_ensure        = 'latest',
@@ -50,10 +52,16 @@ class sensu_handlers(
   $region                = $::datacenter,
   $datacenter            = $::datacenter,
   $dashboard_link        = "https://sensu.${::domain}",
+  $use_embedded_ruby     = false,
 ) {
 
   validate_hash($teams)
   validate_bool($include_graphite, $include_aws_prune)
+
+  $gem_provider = $use_embedded_ruby ? {
+    true    => 'sensu_gem',
+    default => 'gem'
+  }
 
   file { '/etc/sensu/handlers/base.rb':
     source => 'puppet:///modules/sensu_handlers/base.rb',

--- a/manifests/jira.pp
+++ b/manifests/jira.pp
@@ -2,9 +2,21 @@
 #
 # Sensu handler to open and close Jira tickets for you.
 #
-class sensu_handlers::jira inherits sensu_handlers {
+class sensu_handlers::jira (
+  $dependencies = {
+    'jira-ruby' => {
+      ensure   => '0.1.9',
+      provider => $gem_provider,
+    }
+  }
+) inherits sensu_handlers {
 
-  package { 'rubygem-jira-ruby': ensure => '0.1.9' } ->
+  create_resources(
+    'package',
+    $dependencies,
+    { before => Sensu::Handler['jira'] }
+  )
+
   sensu::filter { 'ticket_filter':
     attributes => { 'check' => { 'ticket' => true } },
   } ->

--- a/manifests/pagerduty.pp
+++ b/manifests/pagerduty.pp
@@ -2,9 +2,18 @@
 #
 # Sensu handler for communicating with Pagerduty
 #
-class sensu_handlers::pagerduty inherits sensu_handlers {
+class sensu_handlers::pagerduty (
+  $dependencies = {
+    'redphone' => { provider => $gem_provider },
+  }
+) inherits sensu_handlers {
 
-  ensure_packages(['rubygem-redphone'])
+  create_resources(
+    package,
+    $dependencies,
+    { before => Sensu::Handler['pagerduty'] }
+  )
+
   sensu::filter { 'page_filter':
     attributes => { 'check' => { 'page' => true } },
   } ->
@@ -14,9 +23,8 @@ class sensu_handlers::pagerduty inherits sensu_handlers {
     config  => {
       teams => $teams,
     },
-    require => [ Package['rubygem-redphone'] ],
     filters => [ 'page_filter' ],
-  }
+  } ->
   # If we are going to send pagerduty alerts, we need to be sure it actually is up
   monitoring_check { 'check_pagerduty':
     check_every => '60m',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,30 +2,63 @@ require 'spec_helper'
 
 describe 'sensu_handlers', :type => :class do
 
-
   let(:facts) {{
     :osfamily => 'Debian',
     :lsbdistid => 'debian',
   }}
 
-  context 'By default, it needs teams to be provided' do
-    it { should_not compile }
+  let(:teams) {{
+    'operations' => {}
+  }}
+
+  describe "teams" do
+    context 'By default, it needs teams to be provided' do
+      it { should_not compile }
+    end
+
+    context 'With teams' do
+      let(:params) {{
+        :jira_username => 'foo',
+        :jira_password => 'bar',
+        :jira_site => 'https://jira.mycompany.com',
+        :teams     => teams
+      }}
+      let(:hiera_data) {{
+        :'sensu_handlers::teams' => teams
+      }}
+      it { should compile }
+    end
   end
 
-  context 'With teams' do
-    let(:teams) {{
-      'operations' => {}
-    }}
+  describe 'use_embedded_ruby' do
+    let(:pre_condition) do
+      <<-EOM
+        class sensu_handlers::test () inherits sensu_handlers {
+          package{'foo': provider => $gem_provider }
+        }
+      EOM
+    end
+
     let(:params) {{
-      :jira_username => 'foo',
-      :jira_password => 'bar',
-      :jira_site => 'https://jira.mycompany.com',
-      :teams     => teams
+      :default_handler_array =>  ['test'],
+      :use_embedded_ruby     => use_embedded_ruby,
+      :teams                 => teams
     }}
-    let(:hiera_data) {{
-      :'sensu_handlers::teams' => teams
-    }}
-    it { should compile }
+
+    context "when true" do
+      let(:use_embedded_ruby)  { true }
+      it "sets $gem_provider to sensu_gem" do
+        should create_package(:foo).with_provider('sensu_gem')
+      end
+    end
+
+    context "when false" do
+      let(:use_embedded_ruby)  { false }
+      it "sets $gem_provider to gem" do
+        should create_package(:foo).with_provider('gem')
+      end
+    end
+
   end
 
 end

--- a/spec/classes/mailer_spec.rb
+++ b/spec/classes/mailer_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe "sensu_handlers::mailer" do
+  let(:facts) {{
+    :osfamily => 'Debian',
+    :lsbdistid => 'debian',
+  }}
+  let(:teams) {{
+    'operations' => {}
+  }}
+  let(:hiera_data) {{
+    'sensu_handlers::teams' => teams
+  }}
+
+  it { should compile }
+
+  describe "dependencies param" do
+    context "when left to default" do
+      it { should contain_package('nagios-plugins-basic')      }
+      it { should contain_package('mail').with_provider('gem') }
+
+      context "with use_embeded_ruby set in sensu_handlers" do
+        let(:pre_condition) do
+          %( class {'sensu_handlers':  use_embedded_ruby => true } )
+        end
+        it { should contain_package('mail').with_provider('sensu_gem') }
+      end
+    end
+
+    context "when empty hash" do
+      let(:params) {{ :dependencies => {} }}
+      it { should_not contain_package('nagios-plugins-basic') }
+      it { should_not contain_package('mail')                 }
+    end
+
+    context "when passed override" do
+      let(:params) {{
+        :dependencies => { 'foo' => { 'provider' => 'bar' } }
+      }}
+      it { should_not contain_package('nagios-plugins-basic') }
+      it { should_not contain_package('mail')                 }
+      it { should contain_package('foo').with_provider('bar') }
+    end
+
+  end
+end


### PR DESCRIPTION
ok one last style to propose.   alternate to #60 and #65.  mostly like #60 but supports 
use_embeded_ruby to install default deps with sensu

each handler takes a dependencies hash as a param suitble for passing
to create_resources(package,$dependencies), the defaults should work for
most people. pass a different hash to override the dependencies.

add use_embeded_ruby param which sets $sensu_handlers::gem_provider to
either gem or sensu_gem if use_embeded_ruby is true.

default dependencies that are gems use `provider => $gem_provider`