### PR TITLE
timeout hack

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -3,6 +3,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
+require 'timeout'
 
 # Taken from https://github.com/flori/term-ansicolor/blob/e6086b7fddf53c53f8022acc1920f435e65b5e51/lib/term/ansicolor.rb#L60
 COLOR_REGEX = /\e\[(?:(?:[349]|10)[0-7]|[0-9]|[34]8;5;\d{1,3})?m/
@@ -220,6 +221,14 @@ BODY
 
   def handler_settings
     settings[settings_key]
+  end
+
+  # force all timeout calls to go through this method where all we do
+  # is ensure timeout value is at least 10; it's meant for
+  # timeout calls hard coded in Sensu::Handler that are too aggressive
+  def timeout(arg)
+    raise "timeout without block" unless block_given?
+    Timeout::timeout(arg > 9 ? arg : 10) { yield }
   end
 
 end

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -12,6 +12,14 @@ require "#{File.dirname(__FILE__)}/../../files/base"
 
 class BaseHandler
   attr_accessor :settings
+
+  def fake_handle1
+    timeout(2) { sleep 5; :ok }
+  end
+
+  def fake_handle2
+    timeout(2) { sleep 11 }
+  end
 end
 
 describe BaseHandler do
@@ -392,5 +400,12 @@ describe BaseHandler do
       }
     end
   end # End of context 'With display name tag'
+
+  context "timeout override" do
+    it {
+      expect(subject.fake_handle1).to eql(:ok)
+      expect { subject.fake_handle2 }.to raise_error
+    }
+  end
 
 end # End describe  


### PR DESCRIPTION
I am not entirely convinced this is a good idea but it's easier to discuss working code than abstract thoughts so let's discuss.

Sensu::Handler hard codes timeout to 2 seconds in a couple of places. It bites us sometimes when our handlers try to connect to sensu-api to see whether a host or check is silenced. Percentage of handler invocations when this happens is minuscule (based on quick scan of sensu-server.log for one day on one sensu server) but it still could be a difference between paging on a silenced check or not.

In this hack, timeout(2) will actually become timeout(10).