### PR TITLE
api_client settings

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -164,6 +164,7 @@ BODY
   # create an alert or not:
   #
   def filter_repeated
+    reset_api_settings!
     if @event['check']['name'] == 'keepalive'
       # Keepalives are a special case because they don't emit an interval.
       # They emit a heartbeat every 20 seconds per
@@ -222,6 +223,10 @@ BODY
     settings[settings_key]
   end
 
+  def reset_api_settings!
+    @settings['api'].merge!(settings['api_client']) if settings['api_client']
+    settings['api']
+  end
 
   ##################################
   ## channels helper for chat handlers

--- a/files/base.rb
+++ b/files/base.rb
@@ -225,7 +225,6 @@ BODY
 
   def reset_api_settings!
     @settings['api'].merge!(settings['api_client']) if settings['api_client']
-    settings['api']
   end
 
   ##################################

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -62,5 +62,31 @@ describe 'sensu_handlers', :type => :class do
 
   end
 
+  describe 'api_client_config' do
+    let(:hiera_data) {{
+      'sensu_handlers::teams' => { 'operations' => {} },
+      'sensu_handlers::mailer::mail_from' => 'hello@example.com',
+    }}
+
+    context 'when empty (default)' do
+      it {
+        should_not contain_file('/etc/sensu/conf.d/api_client.json')
+      }
+    end
+
+    context 'when set' do
+      let(:hiera_data) {{
+        'sensu_handlers::teams' => { 'operations' => {} },
+        'sensu_handlers::mailer::mail_from' => 'hello@example.com',
+        'sensu_handlers::api_client_config' => { 'host' => 'foo', 'port' => 12345 },
+      }}
+      it {
+        should contain_file('/etc/sensu/conf.d/api_client.json') \
+                 .with_content(/"host": "foo"/) \
+                 .with_content(/"port": 12345/)
+      }
+    end
+  end
+
 end
 

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -502,5 +502,31 @@ describe BaseHandler do
 
   end
 
+  describe 'api_client settings overrides' do
+    settings_api = { 'api' => { 'host' => 'foo', 'port' => 12345 } }
+    settings_api_client = { 'api_client' => { 'host' => 'bar', 'port' => 54321 } }
+
+    context 'when api_client is not defined' do
+      it 'should not change settings["api"]' do
+        subject.settings = settings_api
+        expect(subject.reset_api_settings!).to eql(settings_api['api'])
+      end
+    end
+
+    context 'when api_client is empty hash' do
+      it 'should not change settings["api"]' do
+        subject.settings = settings_api.merge('api_client' => {})
+        expect(subject.reset_api_settings!).to eql(settings_api['api'])
+      end
+    end
+
+    context 'when api_client is set' do
+      it 'should adjust settings["api"]' do
+        subject.settings = settings_api.merge(settings_api_client)
+        expect(subject.reset_api_settings!).to eql(settings_api_client['api_client'])
+      end
+    end
+  end
+
 
 end # End describe

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -509,21 +509,24 @@ describe BaseHandler do
     context 'when api_client is not defined' do
       it 'should not change settings["api"]' do
         subject.settings = settings_api
-        expect(subject.reset_api_settings!).to eql(settings_api['api'])
+        subject.reset_api_settings!
+        expect(subject.settings['api']).to eql(settings_api['api'])
       end
     end
 
     context 'when api_client is empty hash' do
       it 'should not change settings["api"]' do
         subject.settings = settings_api.merge('api_client' => {})
-        expect(subject.reset_api_settings!).to eql(settings_api['api'])
+        subject.reset_api_settings!
+        expect(subject.settings['api']).to eql(settings_api['api'])
       end
     end
 
     context 'when api_client is set' do
       it 'should adjust settings["api"]' do
         subject.settings = settings_api.merge(settings_api_client)
-        expect(subject.reset_api_settings!).to eql(settings_api_client['api_client'])
+        subject.reset_api_settings!
+        expect(subject.settings['api']).to eql(settings_api_client['api_client'])
       end
     end
   end


### PR DESCRIPTION
This is a fix for a tricky situation.

When sensu-api starts, it reads /etc/sensu/conf.d/api.json to find out its configuration - such as what port it should be listening on.

Sensu handlers however use this file to find out which sensu-api process they should be talking to - https://github.com/sensu-plugins/sensu-plugin/blob/master/lib/sensu-handler.rb#L84

This is bad for deployments that have many sensu-api processes running (for example behind haproxy) where it's better for sensu handlers to connect to some other (host, port), not ones from api.json

This change makes it happen via api_client_config param to sensu_handlers which I expect we could set in hiera to whatever we want handlers to connect to when they want to talk to API (it's expected to be a hash).

Internal ticket is OPS-8402