### PR TITLE
add client_display_name to full_description output for jira handler

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -67,11 +67,15 @@ class BaseHandler < Sensu::Handler
     @event['check']['tip']
   end
 
-  def description(maxlen=100000)
-    description = @event['check']['notification']
+  def client_display_name
     client_display_name = @event['client']['tags']['Display Name'] rescue nil
     client_display_name = @event['client']['name'] if
       client_display_name.nil? || client_display_name.empty?
+    client_display_name
+  end
+
+  def description(maxlen=100000)
+    description = @event['check']['notification']
     description ||= [client_display_name, @event['check']['name'], uncolorize(@event['check']['output'])].join(' : ')
     if event_is_critical? or event_is_warning?
       toadd = ""
@@ -101,7 +105,7 @@ Timestamp: #{Time.at(@event['check']['issued'])}
 Occurrences:  #{@event['occurrences']}
 
 Team: #{team_name}
-Host: #{@event['client']['name']}
+Host: #{client_display_name}
 Address:  #{@event['client']['address']}
 Check Name:  #{@event['check']['name']}
 

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -531,5 +531,32 @@ describe BaseHandler do
     end
   end
 
+  describe 'client_display_name' do
+    event = {
+      'client' => { 'name' => 'foo' },
+      'check'  => { 'output' => 'hello world',
+                    'issued' => 1,
+                    'status' => 2,
+                    'team'   => 'noop',
+                  },
+    }
+
+    context 'when Display Name tag is not set' do
+      it 'should be the same as client name' do
+        subject.event = event
+        expect(subject.client_display_name).to eql('foo')
+        expect(subject.full_description).to match(/Host: foo/)
+      end
+    end
+
+    context 'when Display Name tag is set' do
+      it 'should be set correctly' do
+        subject.event = event
+        subject.event['client']['tags'] = { 'Display Name' => 'bar' }
+        expect(subject.client_display_name).to eql('bar')
+        expect(subject.full_description).to match(/Host: bar/)
+      end
+    end
+  end
 
 end # End describe


### PR DESCRIPTION
Jira handler uses full_description method. The goal here is to have jira tickets include host's role from 'Display Name' tag, similar to what we use for description in pagerduty handler.