### PR TITLE
always let handlers process recovery messages

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -232,6 +232,18 @@ BODY
     @settings['api'].merge!(settings['api_client']) if settings['api_client']
   end
 
+  # override upstream method; if this is a recovery, do not filter
+  # it based on any dependency or whether it's disabled or not -
+  # always let recovery be processed by handlers
+  def filter
+    unless event_is_ok?
+      filter_disabled
+      filter_repeated
+      filter_silenced
+      filter_dependencies
+    end
+  end
+
   ##################################
   ## channels helper for chat handlers
   def channel_keys


### PR DESCRIPTION
Internally please see OPS-8850.

We currently suppress some recoveries from reaching jira and pagerduty (and all other handlers too) when they are filtered as disabled, silenced or dependency exists. This is not good.

Let's make sure all recoveries always reach our handlers.

Upstream filter method is at https://github.com/sensu-plugins/sensu-plugin/blob/master/lib/sensu-handler.rb#L29