### PR TITLE
add num_occurrences_filter as sensu extension

### DIFF
--- a/files/num_occurrences_filter.rb
+++ b/files/num_occurrences_filter.rb
@@ -72,7 +72,7 @@ module Sensu::Extension
           # If our number of failed attempts is an exponent of 2
           if power_of_two?(number_of_failed_attempts)
             # Then This is our MOMENT!
-            return ALLOW_PROCESSING, 'can be processed now'
+            return ALLOW_PROCESSING, "can be processed now: #{number_of_failed_attempts}"
           else
             return STOP_PROCESSING,
                    "not on a power of two: #{number_of_failed_attempts}"
@@ -91,7 +91,7 @@ module Sensu::Extension
     end
 
     def power_of_two?(x)
-      return false if x.odd?
+      return false if x > 1 && x.odd?
       while ( x % 2) == 0 and x > 1
         x /= 2
       end

--- a/files/num_occurrences_filter.rb
+++ b/files/num_occurrences_filter.rb
@@ -1,0 +1,106 @@
+#
+# This code will run inside sensu-server process. Be careful with external calls
+# that could disrupt event loop.
+#
+module Sensu::Extension
+  class NumOccurrences < Filter
+
+    STOP_PROCESSING  = 0
+    ALLOW_PROCESSING = 1
+
+    def name
+      'num_occurrences_filter'
+    end
+
+    def description
+      'filter events based on the number of occurrences'
+    end
+
+    def run(event)
+      begin
+        rc, msg = filter_by_num_occurrences(event)
+        yield msg, rc
+      rescue => e
+        # filter crashed - let's pass this on to handler
+        yield e.message, ALLOW_PROCESSING
+      end
+    end
+
+    # This used to be in base.rb but was moved into a sensu extension
+    # to avoid forking handlers for events which they are not going to handle.
+    #
+    # There are no external calls here, only math.
+    #
+    # == Custom Yelp Filter Logic
+    # We have multiple output handlers and routing logic, and we to ensure
+    # that both active and passive checks and take advantage of it
+    # Addionally we want to simplify the timing logic as much as possible.
+    #
+    # To that end we take the following event data to determine if we should
+    # create an alert or not:
+    #
+    def filter_by_num_occurrences(event)
+      if event[:check][:name] == 'keepalive'
+        # Keepalives are a special case because they don't emit an interval.
+        # They emit a heartbeat every 20 seconds per
+        # http://sensuapp.org/docs/0.12/keepalives
+        interval = 20
+      else
+        interval = event[:check][:interval].to_i || 0
+      end
+      alert_after = event[:check][:alert_after].to_i || 0
+
+      # nil.to_i == 0
+      # 0 || 1   == 0
+      realert_every = ( event[:check][:realert_every] || 1 ).to_i
+
+      initial_failing_occurrences = interval > 0 ? (alert_after / interval) : 0
+      number_of_failed_attempts = event[:occurrences] - initial_failing_occurrences
+
+      # Don't bother acting if we haven't hit the alert_after threshold
+      if number_of_failed_attempts < 1
+        return STOP_PROCESSING, strip(%Q{
+          Not failing long enough, only #{number_of_failed_attempts} after
+          #{initial_failing_occurrences} initial failing occurrences
+        })
+      # If we have an interval, and this is a creation event, that means we are
+      # an active check
+      # Lets also filter based on the realert_every setting
+      elsif interval > 0 and event[:action] == :create
+        # Special case of exponential backoff
+        if realert_every == -1
+          # If our number of failed attempts is an exponent of 2
+          if power_of_two?(number_of_failed_attempts)
+            # Then This is our MOMENT!
+            return ALLOW_PROCESSING, 'can be processed now'
+          else
+            return STOP_PROCESSING,
+                   "not on a power of two: #{number_of_failed_attempts}"
+          end
+        elsif (number_of_failed_attempts - 1) % realert_every != 0
+          # Now bail if we are not in the realert_every cycle
+          return STOP_PROCESSING, strip(%Q{
+            only handling every #{realert_every} occurrences, and we are at
+            #{number_of_failed_attempts}
+          })
+        end
+      end
+
+      # if we reached here, we didn't find any reason to block processing
+      return ALLOW_PROCESSING, 'the end'
+    end
+
+    def power_of_two?(x)
+      return false if x.odd?
+      while ( x % 2) == 0 and x > 1
+        x /= 2
+      end
+      x==1
+    end
+
+    def strip(s)
+      s.strip.gsub(/[\s\n]+/, ' ')
+    end
+
+  end
+end

--- a/manifests/jira.pp
+++ b/manifests/jira.pp
@@ -29,7 +29,10 @@ class sensu_handlers::jira (
       password => $jira_password,
       site     => $jira_site,
     },
-    filters => [ 'ticket_filter' ],
+    filters => flatten([
+      'ticket_filter',
+      $sensu_handlers::num_occurrences_filter,
+    ]),
   }
   if $::lsbdistcodename == 'Lucid' {
     # So sorry for the httprb monkeypatch. It is Debian bug 564168 that took

--- a/manifests/mailer.pp
+++ b/manifests/mailer.pp
@@ -27,6 +27,9 @@ class sensu_handlers::mailer (
   sensu::handler { 'mailer':
     type    => 'pipe',
     source  => 'puppet:///modules/sensu_handlers/mailer.rb',
+    filters => flatten([
+      $sensu_handlers::num_occurrences_filter,
+    ]),
     config  => {
       teams     => $teams,
       mail_from => $mail_from

--- a/manifests/nodebot.pp
+++ b/manifests/nodebot.pp
@@ -8,6 +8,9 @@ class sensu_handlers::nodebot inherits sensu_handlers {
  sensu::handler { 'nodebot':
     type    => 'pipe',
     source  => 'puppet:///modules/sensu_handlers/nodebot.rb',
+    filters => flatten([
+      $sensu_handlers::num_occurrences_filter,
+    ]),
     config  => {
       teams => $teams,
     }

--- a/manifests/pagerduty.pp
+++ b/manifests/pagerduty.pp
@@ -23,7 +23,10 @@ class sensu_handlers::pagerduty (
     config  => {
       teams => $teams,
     },
-    filters => [ 'page_filter' ],
+    filters => flatten([
+      'page_filter',
+      $sensu_handlers::num_occurrences_filter,
+    ]),
   } ->
   # If we are going to send pagerduty alerts, we need to be sure it actually is up
   monitoring_check { 'check_pagerduty':

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -88,5 +88,39 @@ describe 'sensu_handlers', :type => :class do
     end
   end
 
+  describe 'num_occurrences_filter' do
+    let(:hiera_data) {{
+      'sensu_handlers::teams' => { 'operations' => {} },
+      'sensu_handlers::mailer::mail_from' => 'hello@example.com',
+    }}
+
+    context 'by default' do
+      it {
+        should_not contain_file('/etc/sensu/extensions/num_occurrences_filter.rb')
+        should contain_sensu__handler('jira') \
+          .with_filters(['ticket_filter'])
+        should contain_sensu__handler('pagerduty') \
+          .with_filters(['page_filter'])
+        should contain_sensu__handler('nodebot').with_filters([])
+        should contain_sensu__handler('mailer').with_filters([])
+      }
+    end
+
+    context 'when use_num_occurrences_filter is set to true' do
+      let(:params) {{ :use_num_occurrences_filter => true }}
+      it {
+        should contain_file('/etc/sensu/extensions/num_occurrences_filter.rb')
+        should contain_sensu__handler('jira') \
+          .with_filters(['ticket_filter', 'num_occurrences_filter'])
+        should contain_sensu__handler('pagerduty') \
+          .with_filters(['page_filter', 'num_occurrences_filter'])
+        should contain_sensu__handler('nodebot') \
+          .with_filters(['num_occurrences_filter'])
+        should contain_sensu__handler('mailer') \
+          .with_filters(['num_occurrences_filter'])
+      }
+    end
+  end
+
 end
 

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -320,7 +320,7 @@ describe BaseHandler do
         expect(subject.filter_repeated).to eql(nil)
       end
     end
-    context "When exponential backoff, and alert_after, it should not alert the fith time" do
+    context "When exponential backoff, and alert_after, it should alert the fith time" do
       it do
         subject.event['occurrences'] = 5
         subject.event['check']['interval'] = 20

--- a/spec/functions/num_occurrences_filter_spec.rb
+++ b/spec/functions/num_occurrences_filter_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+module Sensu::Extension
+  class Filter
+  end
+end
+
+require "#{File.dirname(__FILE__)}/../../files/num_occurrences_filter"
+
+describe Sensu::Extension::NumOccurrences do
+
+  subject { Sensu::Extension::NumOccurrences.new }
+
+  context 'without argument' do
+    it 'should raise exception' do
+      expect { subject.filter_by_num_occurrences }.to raise_error
+    end
+  end
+
+  context 'when not failing long enough' do
+    it 'should return STOP_PROCESSING' do
+      event = {
+        :check => {
+          :interval => 60,
+          :alert_after => 300,
+        },
+        :occurrences => 2
+      }
+      expect(subject.filter_by_num_occurrences(event).first).to eql(
+        Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+      expect(subject.filter_by_num_occurrences(event).last).to match(
+        /Not failing long enough/)
+    end
+  end
+
+  context 'exponential backoff' do
+    event = {
+      :check => {
+        :interval => 60,
+        :alert_after => 300,
+        :realert_every => -1,
+      },
+      :action => :create,
+    }
+
+    it 'when not on power of two, should return STOP_PROCESSING' do
+      [ 15, 24 ].each do |i|
+        expect(subject.filter_by_num_occurrences(
+          event.merge(:occurrences => i)).first).to eql(
+            Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+        expect(subject.filter_by_num_occurrences(
+          event.merge(:occurrences => i)).last).to match(
+            /not on a power of two/)
+      end
+    end
+
+    it 'when on power of two, should return ALLOW_PROCESSING' do
+      expect(subject.filter_by_num_occurrences(
+        event.merge(:occurrences => 261)).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      expect(subject.filter_by_num_occurrences(
+        event.merge(:occurrences => 261)).last).to match(
+          /can be processed/)
+    end
+  end
+
+  context 'with realert_every' do
+    it 'should return STOP_PROCESSING' do
+      event = {
+        :check => {
+          :interval => 60,
+          :alert_after => 300,
+          :realert_every => 60,
+        },
+        :action => :create,
+        :occurrences => 99,
+      }
+
+      expect(subject.filter_by_num_occurrences(event).first).to eql(
+        Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+      expect(subject.filter_by_num_occurrences(event).last).to match(
+        /only handling every 60 /)
+    end
+  end
+
+end

--- a/spec/functions/num_occurrences_filter_spec.rb
+++ b/spec/functions/num_occurrences_filter_spec.rb
@@ -83,4 +83,314 @@ describe Sensu::Extension::NumOccurrences do
     end
   end
 
+  context 'tests from "check filter_repeated" context in base_spec.rb' do
+    context 'It should not fire before alert_after' do
+      it do
+        event = {
+          :check => {
+            :interval => 60,
+            :alert_after => 120,
+            :realert_every => 1
+          },
+          :action => :create,
+          :occurrences => 1
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+        expect(subject.filter_by_num_occurrences(event).last).to match(
+          /Not failing long enough/)
+      end
+    end
+
+    context %q{It should not fire an alert after one alert_after period,
+               because that would be the same as alert_after = 0} do
+      it do
+        event = {
+          :check => {
+            :interval => 60,
+            :alert_after => 60,
+            :realert_every => 100000
+          },
+          :occurrences => 1,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+        expect(subject.filter_by_num_occurrences(event).last).to match(
+          /Not failing long enough/)
+      end
+    end
+
+    context %q{It should fire an alert after it first reaches the alert_after,
+               regardless of the realert_every} do
+      it do
+        event = {
+          :check => {
+            :interval => 60,
+            :alert_after => 120,
+            :realert_every => 100000
+          },
+          :occurrences => 3,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      end
+    end
+
+    context %q{It should fire an alert after the first check,
+               even if alert_after == 0} do
+      it do
+        event = {
+          :check => {
+            :interval => 10,
+            :alert_after => 0,
+            :realert_every => 30
+          },
+          :occurrences => 1,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      end
+    end
+
+    context %q{It should fire an event after the first check,
+               if alert_after == 0 and realert_every 1} do
+      it do
+        event = {
+          :check => {
+            :interval => 10,
+            :alert_after => 0,
+            :realert_every => 1
+          },
+          :occurrences => 1,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      end
+    end
+
+    context 'interval 0 no divide by 0 error' do
+      it do
+        event = {
+          :check => {
+            :interval => 0,
+          },
+          :occurrences => 2,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      end
+    end
+
+    context 'When exponential backoff, it should alert the first time' do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :realert_every => -1
+          },
+          :occurrences => 1,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      end
+    end
+
+    context 'When exponential backoff, it should alert the second time' do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :realert_every => -1
+          },
+          :occurrences => 2,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      end
+    end
+
+    context 'When exponential backoff, it should not alert the third time' do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :realert_every => -1
+          },
+          :occurrences => 3,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+        expect(subject.filter_by_num_occurrences(event).last).to match(
+          /not on a power of two/)
+      end
+    end
+
+    context 'When exponential backoff, it should alert the fourth time' do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :realert_every => -1
+          },
+          :occurrences => 4,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      end
+    end
+
+    context 'When exponential backoff, it should not alert the fifth time' do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :realert_every => -1
+          },
+          :occurrences => 5,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+        expect(subject.filter_by_num_occurrences(event).last).to match(
+          /not on a power of two/)
+      end
+    end
+
+    context %q{When exponential backoff, and alert_after,
+               it should not alert the first time} do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :alert_after => 60,
+            :realert_every => -1
+          },
+          :occurrences => 1,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+        expect(subject.filter_by_num_occurrences(event).last).to match(
+          /Not failing long enough/)
+      end
+    end
+
+    context %q{When exponential backoff, and alert_after,
+               it should not alert the second time} do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :alert_after => 60,
+            :realert_every => -1
+          },
+          :occurrences => 2,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+        expect(subject.filter_by_num_occurrences(event).last).to match(
+          /Not failing long enough/)
+      end
+    end
+
+    context %q{When exponential backoff, and alert_after,
+               it should not alert the third time} do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :alert_after => 60,
+            :realert_every => -1
+          },
+          :occurrences => 3,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+        expect(subject.filter_by_num_occurrences(event).last).to match(
+         /Not failing long enough/)
+      end
+    end
+
+    context %q{When exponential backoff, and alert_after,
+               it should alert the fourth time} do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :alert_after => 60,
+            :realert_every => -1
+          },
+          :occurrences => 4,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      end
+    end
+
+    context %q{When exponential backoff, and alert_after,
+               it should alert the fifth time} do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :alert_after => 60,
+            :realert_every => -1
+          },
+          :occurrences => 5,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      end
+    end
+
+    context %q{When exponential backoff, and alert_after,
+               it should not alert the sixth time} do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :alert_after => 60,
+            :realert_every => -1
+          },
+          :occurrences => 6,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::STOP_PROCESSING)
+        expect(subject.filter_by_num_occurrences(event).last).to match(
+          /not on a power of two/)
+      end
+    end
+
+    context %q{When realert_every is not set,
+               it should treat realert_every as 1} do
+      it do
+        event = {
+          :check => {
+            :interval => 20,
+            :alert_after => 60
+          },
+          :occurrences => 6,
+          :action => :create
+        }
+        expect(subject.filter_by_num_occurrences(event).first).to eql(
+          Sensu::Extension::NumOccurrences::ALLOW_PROCESSING)
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
This moves some filtering logic from handlers to a sensu extension filter that will run inside sensu-server process.

sensu extension was tested internally with a noop handler.

By default this is off and can be enabled in hiera per host or per region, etc.