### PR TITLE
Reduce duplicate pages by having a consistent incident key across habitats

### DIFF
--- a/files/pagerduty.rb
+++ b/files/pagerduty.rb
@@ -3,12 +3,12 @@
 require "#{File.dirname(__FILE__)}/base"
 
 class Pagerduty < BaseHandler
-  def habitat
-    @event['check']['habitat']
+  def region
+    @event['check']['region']
   end
 
   def incident_key
-    "sensu #{habitat} #{@event['client']['name']} #{@event['check']['name']}"
+    "#{@event['client']['name']}/#{@event['check']['name']}"
   end
 
   def api_key

--- a/spec/functions/pagerduty_spec.rb
+++ b/spec/functions/pagerduty_spec.rb
@@ -80,7 +80,7 @@ describe Pagerduty do
       it "logs an error when we time out 3 times" do
         subject.timeout_count = 4
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- timed out while attempting to trigger an incident -- sensu somehabitat some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- timed out while attempting to trigger an incident -- sensu someregion some.client mycoolcheck')
       end
       it "can succeed if we time out once" do
         subject.timeout_count = 1
@@ -95,18 +95,18 @@ describe Pagerduty do
       it "Fails if we error 3 times" do
         expect(subject).to receive(:trigger_incident).and_return(false, false, false)
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- failed to trigger incident -- sensu somehabitat some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- failed to trigger incident -- sensu someregion some.client mycoolcheck')
       end
       it "Succeeds if we error 2 times" do
         expect(subject).to receive(:trigger_incident).and_return(false, false, true)
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu somehabitat some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu someregion some.client mycoolcheck')
       end
       it "Succeeds if we timeout then error once" do
         subject.timeout_count = 1
         expect(subject).to receive(:trigger_incident).and_return(false, true)
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu somehabitat some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu someregion some.client mycoolcheck')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ module SensuHandlerTestHelper
     event['check']['status'] ||= 0
     event['check']['output'] ||= 'some check output'
     event['check']['issued'] ||= Time.now()
-    event['check']['habitat'] = 'somehabitat'
+    event['check']['region'] = 'someregion'
     subject.event = event
     subject.settings          = Hash.new
     subject.settings['default']  = Hash.new


### PR DESCRIPTION
Internal ticket OPSIMP-227

Our sensu servers often cross habitats.

When we have incidents that specify a "source" field, they might come in from any number of servers that might be in different habitats. This causes duplicate pages, even though they all "look" identical, the incident key is different. 

And they linger when only one of them resolves.

This should fix that, but I don't know why the habitat was added in the first place. @bobtfish does this have anything to do with webhooks like git blame suggests?

cc @somic 