### PR TITLE
add rate limiting to jira handler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
+if RUBY_VERSION =~ /^1\./
+  gem 'json_pure', '1.8.1'
+end
+
 gem 'puppetlabs_spec_helper', '0.4.1'      # Apache2
 gem 'rake', '10.1.0'                       # MIT
 gem 'rspec', '2.14.1'                      # MIT

--- a/files/base.rb
+++ b/files/base.rb
@@ -281,5 +281,18 @@ BODY
   ## end channels helper
   #####################################
 
+  def redis
+    return @redis if @redis
+
+    $: << '/etc/sensu/plugins'
+    require 'tiny_redis'
+    redis_config = JSON.parse(
+      File.open('/etc/sensu/conf.d/redis.json') { |f| f.read })
+    @redis = TinyRedis::Client.new(host=redis_config['redis']['host'],
+                                     port=redis_config['redis']['port'])
+    rescue => e
+      raise "Unable to load redis client or connect to sensu redis: #{e.message}"
+  end
+
 end
 


### PR DESCRIPTION
Very experimental, please don't merge - if we agree in principle something like this is desired, I will do more testing and will merge.

I would like to make our handlers smarter. Thought adding simple rate limiting to jira handler could be a good place to start.

Main idea is if N sensu clients trigger event foo, when rate limiting is requested (via monitoring_check sensu_custom field where the limit will be set), we will only create up to certain number of jira issues per minute.

This will have some tricky interactions with our alert_after logic and filtering so actual effect of this change may not be as clear cut but the idea is to avoid spamming jira.

A check must opt in to this and handler should be fully backwards compatible.

Thoughts? Again - please don't merge yet.