### PR TITLE
add page_after param

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -219,6 +219,10 @@ BODY
     end
     alert_after   = @event['check']['alert_after'].to_i || 0
 
+    if self.class.name =~ /Pagerduty/ && @event['check']['page_after']
+      alert_after = @event['check']['page_after'].to_i
+    end
+
     # nil.to_i == 0
     # 0 || 1   == 0
     realert_every = ( @event['check']['realert_every'] || 1 ).to_i 

--- a/files/num_occurrences_filter.rb
+++ b/files/num_occurrences_filter.rb
@@ -103,4 +103,32 @@ module Sensu::Extension
     end
 
   end
+
+  class NumOccurrencesForPagerdutyHandler < NumOccurrences
+
+    def name
+      'num_occurrences_filter_for_pagerduty'
+    end
+
+    def description
+      'filter events based on the number of occurrences for pagerduty handler'
+    end
+
+    def run(event)
+      begin
+        # this requires deep merge;
+        # this is a workaround instead of getting extra libs
+        modified_event = Marshal.load(Marshal.dump(event))
+        modified_event[:check][:alert_after] = event[:check][:page_after] if
+          event[:check][:page_after]
+        rc, msg = filter_by_num_occurrences(modified_event)
+        yield msg, rc
+      rescue => e
+        # filter crashed - let's pass this on to handler
+        yield e.message, ALLOW_PROCESSING
+      end
+    end
+
+  end
+
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,7 @@ class sensu_handlers(
 
   if $use_num_occurrences_filter {
     $num_occurrences_filter = [ 'num_occurrences_filter' ]
+    $num_occurrences_filter_for_pagerduty = [ 'num_occurrences_filter_for_pagerduty' ]
     file { '/etc/sensu/extensions/num_occurrences_filter.rb':
       owner  => 'sensu',
       group  => 'sensu',
@@ -91,6 +92,7 @@ class sensu_handlers(
   }
   else {
     $num_occurrences_filter = []
+    $num_occurrences_filter_for_pagerduty = []
   }
 
   file { '/etc/sensu/handlers/base.rb':

--- a/manifests/pagerduty.pp
+++ b/manifests/pagerduty.pp
@@ -25,7 +25,7 @@ class sensu_handlers::pagerduty (
     },
     filters => flatten([
       'page_filter',
-      $sensu_handlers::num_occurrences_filter,
+      $sensu_handlers::num_occurrences_filter_for_pagerduty,
     ]),
   } ->
   # If we are going to send pagerduty alerts, we need to be sure it actually is up

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -113,7 +113,7 @@ describe 'sensu_handlers', :type => :class do
         should contain_sensu__handler('jira') \
           .with_filters(['ticket_filter', 'num_occurrences_filter'])
         should contain_sensu__handler('pagerduty') \
-          .with_filters(['page_filter', 'num_occurrences_filter'])
+          .with_filters(['page_filter', 'num_occurrences_filter_for_pagerduty'])
         should contain_sensu__handler('nodebot') \
           .with_filters(['num_occurrences_filter'])
         should contain_sensu__handler('mailer') \


### PR DESCRIPTION
Experimental, please do not merge - if this gets shipits, I will do more testing and will merge.

Simple PR that enables the following scenario - the following will ticket after 30 minutes and if an event is not resolved, will page in 3 hours:

```
monitoring_check { 'foo':
  command      => '...',
  ticket       => true,
  page         => true,
  check_every  => '5m',
  alert_after  => '30m',
  sensu_custom => { page_after  => '3h' },
}
```

This is for situations where an event should be escalated differently depending on how long it's been ongoing. My hope is this will allow us to set more events to ticket first and if not caught or addressed in time, page.
