### PR TITLE
Make the jira handler have more jira'y syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 spec/fixtures/modules/
 /bin/
+.bundle/
+vendor/

--- a/files/base.rb
+++ b/files/base.rb
@@ -122,6 +122,33 @@ BODY
     body
   end
 
+  def jira_description
+    body = <<-BODY
+{code}
+#{uncolorize(@event['check']['output'])}
+{code}
+
+Dashboard Link: #{dashboard_link}
+Runbook: #{runbook}
+Tip: #{tip}
+
+Command: {{#{@event['check']['command']}}}
+Status: #{human_check_status()} (#{@event['check']['status']})
+
+Timestamp: #{Time.at(@event['check']['issued'])}
+Occurrences:  #{@event['occurrences']}
+
+Team: #{team_name}
+Host: {{#{client_display_name}}}
+Client Name: {{#{@event['client']['name']}}}
+Address:  #{@event['client']['address']}
+Check Name:  #{@event['check']['name']}
+
+BODY
+    body
+  end
+
+
   def full_description_hash
     {
       'Output' => uncolorize(@event['check']['output']),


### PR DESCRIPTION
Couple of changes:
* Use the {code} jira syntax to get more monospace output. And uncolorize. Hyphens won't get turned into long hypens, column spacing will work correctly, etc.
* Also {code} in the closing output
* New jira_description method to make future room for fancier stuff like color and even more jira-specific syntax stuff?

This will break the autotagging we currently do at Yelp. For that we need to output our own ending `{code}` block ourselves to get back into raw jira syntax mode if we ship this.