### PR TITLE
include environment info is present in incident key

### DIFF
--- a/files/pagerduty.rb
+++ b/files/pagerduty.rb
@@ -7,8 +7,18 @@ class Pagerduty < BaseHandler
     @event['check']['region']
   end
 
+  def environment
+    if handler_settings.has_key?('environment') and !handler_settings['environment'].empty?
+      handler_settings['environment']
+    end
+  end
+
   def incident_key
-    "sensu #{region} #{@event['client']['name']} #{@event['check']['name']}"
+    if environment
+      "sensu #{environment} #{@event['client']['name']} #{@event['check']['name']}"
+    else
+      "sensu #{region} #{@event['client']['name']} #{@event['check']['name']}"
+    end
   end
 
   def api_key
@@ -71,4 +81,3 @@ class Pagerduty < BaseHandler
     end
   end
 end
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,9 @@
 # implemented as a sensu extension, it runs witin sensu-process). If not sure,
 # don't use it and set this to false.
 #
+# [*environment*]
+#  The sensu envionment to be used in incident key
+
 class sensu_handlers(
   $teams,
   $package_ensure             = 'latest',
@@ -64,6 +67,7 @@ class sensu_handlers(
   $use_embedded_ruby          = false,
   $api_client_config          = {},
   $use_num_occurrences_filter = false,
+  $environment                = '',
 ) {
 
   validate_hash($teams, $api_client_config)

--- a/manifests/pagerduty.pp
+++ b/manifests/pagerduty.pp
@@ -21,7 +21,8 @@ class sensu_handlers::pagerduty (
     type    => 'pipe',
     source  => 'puppet:///modules/sensu_handlers/pagerduty.rb',
     config  => {
-      teams => $teams,
+      teams       => $teams,
+      environment => $environment,
     },
     filters => flatten([
       'page_filter',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -29,6 +29,35 @@ describe 'sensu_handlers', :type => :class do
       }}
       it { should compile }
     end
+
+    context 'With teams and without environment' do
+      let(:params) {{
+                      :jira_username => 'foo',
+                      :jira_password => 'bar',
+                      :jira_site => 'https://jira.mycompany.com',
+                      :teams     => teams
+                    }}
+      let(:hiera_data) {{
+                         :'sensu_handlers::teams'             => teams,
+                         :'sensu_handlers::mailer::mail_from' => "foo@bar.com"
+                        }}
+      it { should compile }
+    end
+
+    context 'With teams and with environment' do
+      let(:params) {{
+                      :jira_username     => 'foo',
+                      :jira_password     => 'bar',
+                      :jira_site         => 'https://jira.mycompany.com',
+                      :teams             => teams,
+                      :environment       => 'foobar'
+                    }}
+      let(:hiera_data) {{
+                         :'sensu_handlers::teams'             => teams,
+                         :'sensu_handlers::mailer::mail_from' => "foo@bar.com"
+                        }}
+      it { should compile }
+    end
   end
 
   describe 'use_embedded_ruby' do
@@ -123,4 +152,3 @@ describe 'sensu_handlers', :type => :class do
   end
 
 end
-


### PR DESCRIPTION
Currently pagerduty incident key only includes region
value in the incident key if defined.
Including environment data in the incident key would
help us parse the corresponding sensu server belonging to
the corresponding environment.
This will not break any existing setup but will only modify
the incident key is environment attr is set in the sensu check
definition.

https://v2.developer.pagerduty.com/docs/webhooks-overview
