### PR TITLE
remove {code} from jira ticket description to keep formatting

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -123,9 +123,10 @@ BODY
   end
 
   def jira_description
+    descr = uncolorize(@event['check']['output']).gsub(/\{code\}/, '')
     body = <<-BODY
 {code}
-#{uncolorize(@event['check']['output'])}
+#{descr}
 {code}
 
 Dashboard Link: #{dashboard_link}


### PR DESCRIPTION
See internal OPSALERTS-12557 as an example.