### PR TITLE
include datacenter info in incident key

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -169,7 +169,11 @@ BODY
 
   def dashboard_link
     settings['default']['dashboard_link'].gsub(/\/$/, '')
-    "#{settings['default']['dashboard_link']}/#/client/#{settings['default']['datacenter']}/#{@event['client']['name']}?check=#{@event['check']['name']}" || 'Unknown dashboard link. Please set for the base handler config'
+    "#{settings['default']['dashboard_link']}/#/client/#{datacenter}/#{@event['client']['name']}?check=#{@event['check']['name']}" || 'Unknown dashboard link. Please set for the base handler config'
+  end
+
+  def datacenter
+    settings['default']['datacenter']
   end
 
   def log(line)

--- a/files/pagerduty.rb
+++ b/files/pagerduty.rb
@@ -3,12 +3,9 @@
 require "#{File.dirname(__FILE__)}/base"
 
 class Pagerduty < BaseHandler
-  def region
-    @event['check']['region']
-  end
 
   def incident_key
-    "sensu #{region} #{@event['client']['name']} #{@event['check']['name']}"
+    "sensu #{datacenter} #{@event['client']['name']} #{@event['check']['name']}"
   end
 
   def api_key

--- a/spec/functions/pagerduty_spec.rb
+++ b/spec/functions/pagerduty_spec.rb
@@ -72,15 +72,17 @@ describe Pagerduty do
       subject.handle
     end
 
-    context "Pagerduty times out / errors" do
+    context "Pagerduty with datacenter in incident key times out with / errors" do
       before(:each) do
         subject.event['check']['status'] = 2
         subject.event['check']['team'] = 'operations'
+        subject.event['check']['page'] = true
+        subject.event['check'].delete("region")
       end
       it "logs an error when we time out 3 times" do
         subject.timeout_count = 4
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- timed out while attempting to trigger an incident -- sensu someregion some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- timed out while attempting to trigger an incident -- sensu data_center some.client mycoolcheck')
       end
       it "can succeed if we time out once" do
         subject.timeout_count = 1
@@ -95,18 +97,18 @@ describe Pagerduty do
       it "Fails if we error 3 times" do
         expect(subject).to receive(:trigger_incident).and_return(false, false, false)
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- failed to trigger incident -- sensu someregion some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- failed to trigger incident -- sensu data_center some.client mycoolcheck')
       end
       it "Succeeds if we error 2 times" do
         expect(subject).to receive(:trigger_incident).and_return(false, false, true)
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu someregion some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu data_center some.client mycoolcheck')
       end
       it "Succeeds if we timeout then error once" do
         subject.timeout_count = 1
         expect(subject).to receive(:trigger_incident).and_return(false, true)
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu someregion some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu data_center some.client mycoolcheck')
       end
     end
   end


### PR DESCRIPTION
wrt
https://github.com/Yelp/sensu_handlers/pull/98

Including  datacenter data in the incident key would
help us parse the corresponding sensu server belonging to
the corresponding environment.
This will not break any existing setup but will only modify
the incident key if datacenter attr is set in the default handler config
definition.

https://v2.developer.pagerduty.com/docs/webhooks-overview