### PR TITLE
make the datacenter unique by providing environment info

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -176,6 +176,10 @@ BODY
     settings['default']['datacenter']
   end
 
+  def environment
+    settings['default']['environment']
+  end
+
   def log(line)
     puts line
   end

--- a/files/pagerduty.rb
+++ b/files/pagerduty.rb
@@ -5,7 +5,7 @@ require "#{File.dirname(__FILE__)}/base"
 class Pagerduty < BaseHandler
 
   def incident_key
-    "sensu #{datacenter} #{@event['client']['name']} #{@event['check']['name']}"
+    "sensu #{environment}-#{datacenter} #{@event['client']['name']} #{@event['check']['name']}"
   end
 
   def api_key

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,7 @@ class sensu_handlers(
     config    => {
       dashboard_link => $dashboard_link,
       datacenter     => $datacenter,
+      environment    => $::environment,
     }
   }
 

--- a/spec/functions/pagerduty_spec.rb
+++ b/spec/functions/pagerduty_spec.rb
@@ -82,7 +82,7 @@ describe Pagerduty do
       it "logs an error when we time out 3 times" do
         subject.timeout_count = 4
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- timed out while attempting to trigger an incident -- sensu data_center some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- timed out while attempting to trigger an incident -- sensu some_environment-data_center some.client mycoolcheck')
       end
       it "can succeed if we time out once" do
         subject.timeout_count = 1
@@ -97,18 +97,18 @@ describe Pagerduty do
       it "Fails if we error 3 times" do
         expect(subject).to receive(:trigger_incident).and_return(false, false, false)
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- failed to trigger incident -- sensu data_center some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- failed to trigger incident -- sensu some_environment-data_center some.client mycoolcheck')
       end
       it "Succeeds if we error 2 times" do
         expect(subject).to receive(:trigger_incident).and_return(false, false, true)
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu data_center some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu some_environment-data_center some.client mycoolcheck')
       end
       it "Succeeds if we timeout then error once" do
         subject.timeout_count = 1
         expect(subject).to receive(:trigger_incident).and_return(false, true)
         subject.handle
-        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu data_center some.client mycoolcheck')
+        expect(subject.logged).to eql('pagerduty -- Triggerd incident -- sensu some_environment-data_center some.client mycoolcheck')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ module SensuHandlerTestHelper
     subject.settings['default']  = Hash.new
     subject.settings['default']['dashboard_link'] = 'test_dashboard_link'
     subject.settings['default']['datacenter'] = 'data_center'
+    subject.settings['default']['environment'] = 'some_environment'
     subject.settings[settings_key] ||= Hash.new
     subject.settings[settings_key]['teams'] ||= Hash.new
     subject.settings[settings_key]['teams']['operations'] = {


### PR DESCRIPTION
the earlier [PR](https://github.com/Yelp/sensu_handlers/blob/7bc1edcd3cc8cc712f3f81cff21c64f002dd990a/files/base.rb#L172) provided datacenter key in incident key of pagerduty
but updating datacenter to arbitary value broke the uchiwa dashboard link.
this PR would ensure all dashboard link work well as well pagerduty incident key
remains unique for environment/region combination
