### PR TITLE
add occurrences to jira handler output when closing an issue

### DIFF
--- a/files/jira.rb
+++ b/files/jira.rb
@@ -61,10 +61,12 @@ class Jira < BaseHandler
         puts "Closing Issue: #{issue.key} (#{url})"
 
         occurrences = @event['occurrences'] rescue 'unknown'
+        body = "This is fine:\n{code}#{uncolorize(output)}{code}"
+        body += "\nOccurrences: #{occurrences}"
 
         # Let the world know why we are closing this issue.
         comment = issue.comments.build
-        comment.save(:body => "This is fine (occurrences=#{occurrences}):\n{code}#{uncolorize(output)}{code}")
+        comment.save(:body => body)
 
         # Find the first transition to a closed state that we can perform.
         transitions_to_close = issue.transitions.all.select { |transition|

--- a/files/jira.rb
+++ b/files/jira.rb
@@ -60,9 +60,11 @@ class Jira < BaseHandler
         url = get_options[:site] + '/browse/' + issue.key
         puts "Closing Issue: #{issue.key} (#{url})"
 
+        occurrences = @event['occurrences'] rescue 'unknown'
+
         # Let the world know why we are closing this issue.
         comment = issue.comments.build
-        comment.save(:body => "This is fine:\n{code}#{uncolorize(output)}{code}")
+        comment.save(:body => "This is fine (occurrences=#{occurrences}):\n{code}#{uncolorize(output)}{code}")
 
         # Find the first transition to a closed state that we can perform.
         transitions_to_close = issue.transitions.all.select { |transition|


### PR DESCRIPTION
This will record in jira how many times a check failed before it got resolved.