### PR TITLE
Support labels and display name

### DIFF
--- a/files/jira.rb
+++ b/files/jira.rb
@@ -110,7 +110,7 @@ class Jira < BaseHandler
     return false if !should_ticket?
     return false if !project
     status = human_check_status()
-    summary = @event['check']['name'] + " on " + @event['client']['name'] + " is " + status
+    summary = "#{@event['check']['name']} on #{client_display_name()} is #{status}"
     description = jira_description()
     output = @event['check']['output']
     begin

--- a/files/jira.rb
+++ b/files/jira.rb
@@ -5,10 +5,17 @@ require "#{File.dirname(__FILE__)}/base"
 class Jira < BaseHandler
 
   def build_labels
-    [ "SENSU_#{@event['client']['name']}",
+    user_labels = []
+    user_labels += @event['check']['tags'] || []
+    user_labels += team_data('tags') || []
+    [
+      "SENSU_#{@event['client']['name']}",
       "SENSU_#{@event['check']['name']}",
-      "SENSU", *@event['check']['tags'] ].uniq.reject { |x| x.nil? }.map { |x|
-        x.strip.gsub(/\s+/, '_') }
+      "SENSU",
+      *user_labels
+    ].uniq.reject { |x| x.nil? }.map { |x|
+      x.strip.gsub(/\s+/, '_')
+    }
   end
 
   def create_issue(summary, description, project)

--- a/spec/functions/jira_spec.rb
+++ b/spec/functions/jira_spec.rb
@@ -89,12 +89,22 @@ describe Jira do
       subject.handle
     end
 
-    it "Event has tags when supplied by team data" do
+    it "Creates proper labels when tags are supplied by team data" do
       subject.event['check']['team'] = 'team_with_tags'
       subject.event['check']['tags'] = ["some_tag   with spaces     "]
       subject.event['check']['status'] = 2
       expect(subject.build_labels).to match_array(["SENSU", "SENSU_mycoolcheck", "SENSU_some.client", "some_tag_with_spaces", "test_team_tag", "test_team_tag_2"])
       expect(subject).to receive(:create_issue).and_return(true)
+      subject.handle
+    end
+
+    it "Incorporates client_display_name into message" do
+      subject.event['check']['name'] = 'fake_alert'
+      subject.event['client']['name'] = 'fake_client'
+      # _client_ tags are a hash, vs _check_ tags which are a list
+      subject.event['client']['tags'] = {'Display Name' => 'really_fake_client'}
+      subject.event['check']['status'] = 2
+      expect(subject).to receive(:create_issue).with("fake_alert on really_fake_client is CRITICAL", /.*/, "TEST").and_return(true)
       subject.handle
     end
 

--- a/spec/functions/jira_spec.rb
+++ b/spec/functions/jira_spec.rb
@@ -89,6 +89,15 @@ describe Jira do
       subject.handle
     end
 
+    it "Event has tags when supplied by team data" do
+      subject.event['check']['team'] = 'team_with_tags'
+      subject.event['check']['tags'] = ["some_tag   with spaces     "]
+      subject.event['check']['status'] = 2
+      expect(subject.build_labels).to match_array(["SENSU", "SENSU_mycoolcheck", "SENSU_some.client", "some_tag_with_spaces", "test_team_tag", "test_team_tag_2"])
+      expect(subject).to receive(:create_issue).and_return(true)
+      subject.handle
+    end
+
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,9 @@ module SensuHandlerTestHelper
     subject.settings[settings_key]['teams']['someotherteam'] = {
       'pagerduty_api_key' => 'someotherteam_pagerduty_key'
     }
+    subject.settings[settings_key]['teams']['team_with_tags'] = {
+      'tags' => ['test_team_tag', 'test_team_tag_2']
+    }
     yield(event) if block_given?
   end
 end


### PR DESCRIPTION
This change incorporates two changes:

1. Allow team_data based tags to be injected into jira labels, so that we can do things like have one JIRA project that has a few project specific labels on alerts (e.g. instead of having a separate project for each datastore alert we can have one project with separate labels)
2. Uses the client_display_name in the jira summary instead of the straight up ``['client']['name']``. This allows us to provide the ``display_name`` property on our alerts to tell us what hosts actually mean (instead of fqdn which in AWS in an ASG means about zero).

@somic @solarkennedy 