### PR TITLE
handler must fire resolve if it fired for create

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -229,6 +229,18 @@ BODY
 
     initial_failing_occurrences = interval > 0 ? (alert_after / interval) : 0
     number_of_failed_attempts = @event['occurrences'] - initial_failing_occurrences
+    # sensu 0.26+ only, else never make  occurrences_watermark actionable
+    occurrences_watermark = @event.key?('occurrences_watermark') ? event['occurrences_watermark'] : -1
+
+    # https://github.com/Yelp/sensu_handlers/issues/103
+    # this hack takes care of scenario
+    # when event has triggered at action == create
+    # but did not resolve the corresponding event when action == resolve.
+    # occurrences_watermark > initial_failing_occurrences prove enough occurrences
+    # of the event that triggered create and hence it is safe to filter the event to resolve handler action.
+    if occurrences_watermark > initial_failing_occurrences and @event['action'] == 'resolve'
+      return nil
+    end
 
     # Don't bother acting if we haven't hit the 
     # alert_after threshold

--- a/files/base.rb
+++ b/files/base.rb
@@ -229,17 +229,18 @@ BODY
 
     initial_failing_occurrences = interval > 0 ? (alert_after / interval) : 0
     number_of_failed_attempts = @event['occurrences'] - initial_failing_occurrences
-    # sensu 0.26+ only, else never make  occurrences_watermark actionable
-    occurrences_watermark = @event.key?('occurrences_watermark') ? event['occurrences_watermark'] : -1
 
+    # sensu 0.26+ only, else never make  occurrences_watermark actionable
     # https://github.com/Yelp/sensu_handlers/issues/103
     # this hack takes care of scenario
     # when event has triggered at action == create
     # but did not resolve the corresponding event when action == resolve.
     # occurrences_watermark > initial_failing_occurrences prove enough occurrences
     # of the event that triggered create and hence it is safe to filter the event to resolve handler action.
-    if occurrences_watermark > initial_failing_occurrences and @event['action'] == 'resolve'
-      return nil
+    if (@event.key?('occurrences_watermark') &&
+        @event['occurrences_watermark'] > initial_failing_occurrences &&
+        @event['action'] == 'resolve')
+      return
     end
 
     # Don't bother acting if we haven't hit the 

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -353,6 +353,43 @@ describe BaseHandler do
         expect(subject.filter_repeated).to eql(nil)
       end
     end
+	context "when action == resolve" do
+	  context "when occurrences_watermark > initial_failing_occurrences" do
+        it "it should fire" do
+          subject.event['occurrences'] = 2
+          subject.event['occurrences_watermark'] = 8
+          subject.event['check']['interval'] = 20
+          subject.event['check']['realert_every'] = "-1"
+          subject.event['check']['alert_after'] = 60
+          subject.event['action'] = 'resolve'
+          expect(subject).not_to receive(:bail)
+          expect(subject.filter_repeated).to eql(nil)
+        end
+      end
+	  context "when occurrences_watermark <= initial_failing_occurrences" do
+        it "it should not fire" do
+          subject.event['occurrences'] = 3
+          subject.event['occurrences_watermark'] = 3
+          subject.event['check']['interval'] = 20
+          subject.event['check']['realert_every'] = "-1"
+          subject.event['check']['alert_after'] = 60
+          subject.event['action'] = 'resolve'
+          expect(subject).to receive(:bail)
+          expect(subject.filter_repeated).to eql(nil)
+        end
+      end
+	  context "when no occurrences_watermark" do
+        it "it should not fire" do
+          subject.event['occurrences'] = 3
+          subject.event['check']['interval'] = 20
+          subject.event['check']['realert_every'] = "-1"
+          subject.event['check']['alert_after'] = 60
+          subject.event['action'] = 'resolve'
+          expect(subject).to receive(:bail)
+          expect(subject.filter_repeated).to eql(nil)
+        end
+      end
+    end
   end #End filter repeated
 
   context "With display name tag" do


### PR DESCRIPTION
https://github.com/Yelp/sensu_handlers/issues/103
handler should now fire a resolve if the event was triggered
for create action earlier.
handler should not fire a resolve if the event was not triggered
for create action earlier.