### PR TITLE
refactor slack and nodebot to use base methods

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -330,6 +330,10 @@ BODY
     %w[ pager_channel pager_room ]
   end
 
+  def default_pager_channel
+    "#{team_name}-pages"
+  end
+
   def find_channel(keys, &block)
     keys \
       .map(&block) \
@@ -349,7 +353,7 @@ BODY
   end
 
   def team_pager_channel
-    team_channel(pager_channel_keys)
+    team_channel(pager_channel_keys) || default_pager_channel
   end
 
   def notifications_channel

--- a/files/nodebot.rb
+++ b/files/nodebot.rb
@@ -4,24 +4,17 @@ require "strscan"
 require "#{File.dirname(__FILE__)}/base"
 
 class Nodebot < BaseHandler
-  def pages_irc_channel
-    team_data('pages_irc_channel') || "##{team_name}-pages"
+  def pager_channel_keys
+    %w[ pages_irc_channel ]
+  end
+
+  def channel_keys
+    %w[ irc_channels notifications_irc_channel ]
   end
 
   def channels
-    channels = []
-    # All pages get to the pages_irc_channel
-    if should_page?
-      channels.push pages_irc_channel
-    end
-    # Allow irc_channels override if specified in the check itself
-    if @event['check']['irc_channels']
-      channels.push @event['check']['irc_channels']
-    else
-      team_data('notifications_irc_channel') { |channel| channels.push channel }
-    end
-    # Return channels, but strip out any "#", nodebot doesn't need them
-    channels.flatten.uniq.collect { |x| x.gsub(/#/, '') }
+    # # Return channels, but strip out any "#", nodebot doesn't need them
+    super.flatten.uniq.collect { |x| x.gsub(/#/, '') }
   end
 
   def message

--- a/files/slack.rb
+++ b/files/slack.rb
@@ -9,28 +9,20 @@ class Slack < BaseHandler
     handler_settings['webhook_url']
   end
 
-  def pages_slack_channel
-    team_data('pages_slack_channel') || "##{team_name}-pages"
-  end
-
   def compact_messages
     team_data('slack_compact_message') || false
   end
 
-  def channels
-    channels = []
-    # All pages get to the pages_slack_channel
-    if should_page?
-      channels.push pages_slack_channel
-    end
-    # Allow slack_channels override if specified in the check itself
-    if @event['check']['slack_channels']
-      channels.push @event['check']['slack_channels']
-    else
-      team_data('notifications_slack_channel') { |channel| channels.push channel }
-    end
+  def pager_channel_keys
+    %w[ pages_slack_channel ]
+  end
 
-    channels
+  def channel_keys
+    %w[ slack_channels notifications_slack_channel ]
+  end
+
+  def default_pager_channel
+    "##{team_name}-pages"
   end
 
   def message

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -452,7 +452,7 @@ describe BaseHandler do
       before { check_data['page'] = true }
 
       context "with no team or event level config"  do
-        it { expect(channels).to eq [] }
+        it { expect(channels).to eq ["#{team}-pages"] }
       end
 
       context "with both notification and pager channels configured at team leavel" do

--- a/spec/functions/nodebot_spec.rb
+++ b/spec/functions/nodebot_spec.rb
@@ -36,7 +36,6 @@ describe Nodebot do
       subject.event['check']['team'] = 'operations'
       subject.settings[settings_key]['teams']['operations']['pages_irc_channel'] = '#criticals'
     end
-    it { expect(subject.pages_irc_channel).to eql('#criticals') }
     it { expect(subject.channels).to eql(['criticals']) }
     timestamp_regex = / \(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\)$/
     it { expect(subject.message).to match(timestamp_regex) }
@@ -46,7 +45,6 @@ describe Nodebot do
       subject.event['check']['page'] = true 
       subject.event['check']['team'] = 'operations'
     end
-    it { expect(subject.pages_irc_channel).to eql('#operations-pages') }
     it { expect(subject.channels).to eql(['operations-pages']) }
   end
   context "Notifications channel" do

--- a/spec/functions/slack_spec.rb
+++ b/spec/functions/slack_spec.rb
@@ -1,0 +1,66 @@
+
+require 'spec_helper'
+
+# Intercept the hook that sensu uses to auto-execute checks by entirely replacing
+# the method used in Kernel before loading the handler.
+# This is _terrible_, see also https://github.com/sensu/sensu-plugin/pull/61
+module Kernel
+  def at_exit(&block)
+  end
+end
+
+require "#{File.dirname(__FILE__)}/../../files/slack"
+
+class Slack
+  attr_accessor :settings
+end
+
+describe Slack do
+  include SensuHandlerTestHelper
+
+  # because we are in spec/functions we have included 
+  # Rspec::Puppet::FunctionExampleGroup which has taken over subject
+  subject { described_class.new }
+
+  let(:team)             { 'testteam1' }
+  let(:settings)         { subject.settings[settings_key] }
+  let(:handler_settings) { subject.handler_settings }
+  let(:check_data)       { subject.event['check'] }
+  let(:client_data)      { subject.event['client'] }
+  let(:team_settings)    { settings['teams'][team] }
+
+  before do
+    setup_event!
+    settings['teams'][team] = Hash.new
+    check_data['team']      = 'testteam1'
+    check_data['issued']    = 1438866190
+  end
+
+
+  # two silly tests just for starter
+  specify { expect(subject).to be_a BaseHandler }
+  specify { expect(subject).to be_a Sensu::Handler }
+
+  describe "channels" do
+    let(:channels) { subject.channels } 
+    context "event has page true" do
+      before { check_data['page'] = true }
+
+      context "team data has pages_slack_chanel" do
+        before  { team_settings['pages_slack_channel'] = 'pager-channel' }
+        specify { expect(channels).to eql ['pager-channel'] }
+      end
+
+      context "team data does not have pager_slack_chanel" do
+        specify { expect(channels).to eql ["##{team}-pages"] }
+      end
+
+    end
+
+    context "check data has slack_channels" do
+      before  { check_data['slack_channels'] = 'check-channel' }
+      specify { expect(channels).to eql ["check-channel"] }
+    end
+  end
+
+end


### PR DESCRIPTION
base class has methods to handle the channels logic in a consistent
fashion.