### PR TITLE
handler level config for slack's compact option

### DIFF
--- a/files/slack.rb
+++ b/files/slack.rb
@@ -10,7 +10,10 @@ class Slack < BaseHandler
   end
 
   def compact_messages
-    team_data('slack_compact_message') || false
+    team_compact    = team_data('slack_compact_message')
+    handler_default = !! handler_settings['compact_message']
+
+    team_compact.nil? ? handler_default : team_compact
   end
 
   def pager_channel_keys

--- a/files/slack.rb
+++ b/files/slack.rb
@@ -10,10 +10,9 @@ class Slack < BaseHandler
   end
 
   def compact_messages
-    team_compact    = team_data('slack_compact_message')
-    handler_default = !! handler_settings['compact_message']
-
-    team_compact.nil? ? handler_default : team_compact
+    team_compact = team_data('slack_compact_message')
+    return team_compact unless team_compact.nil?
+    handler_settings['compact_message'] || false
   end
 
   def pager_channel_keys

--- a/spec/functions/slack_spec.rb
+++ b/spec/functions/slack_spec.rb
@@ -63,4 +63,61 @@ describe Slack do
     end
   end
 
+  describe "compact_messages" do
+    let(:compact_messages) { subject.compact_messages }
+
+    context "handler settings compact_message is not set" do
+      context "when slack_compact_message is true in team data" do
+        before  { team_settings['slack_compact_message'] = true  }
+        specify { expect(compact_messages).to be_true }
+      end
+
+      context "when slack_compact_message is false in team data" do
+        before  { team_settings['slack_compact_message'] = false  }
+        specify { expect(compact_messages).to be_false }
+      end
+
+      context "when slack_compact_message is not set in  team data" do
+        specify { expect(compact_messages).to be_false }
+      end
+    end
+
+    context "handler settings compact_message is true" do
+      before { handler_settings['compact_message'] = true }
+
+      context "when slack_compact_message is true in team data" do
+        before  { team_settings['slack_compact_message'] = true  }
+        specify { expect(compact_messages).to be_true }
+      end
+
+      context "when slack_compact_message is false in team data" do
+        before  { team_settings['slack_compact_message'] = false  }
+        specify { expect(compact_messages).to be_false }
+      end
+
+      context "when slack_compact_message is not set in  team data" do
+        specify { expect(compact_messages).to be_true }
+      end
+    end
+
+    context "handler settings compact_message is false" do
+      before { handler_settings['compact_message'] = false }
+
+      context "when slack_compact_message is true in team data" do
+        before  { team_settings['slack_compact_message'] = true  }
+        specify { expect(compact_messages).to be_true }
+      end
+
+      context "when slack_compact_message is false in team data" do
+        before  { team_settings['slack_compact_message'] = false  }
+        specify { expect(compact_messages).to be_false }
+      end
+
+      context "when slack_compact_message is not set in  team data" do
+        specify { expect(compact_messages).to be_false }
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
in anticipation of most teams wanting a compact display allow
the default to be configurable at the handler level.       the default for compact  remains 'false' unless changed. 

