### PR TITLE
puppet support for slack compact_message setting

### DIFF
--- a/manifests/slack.pp
+++ b/manifests/slack.pp
@@ -3,7 +3,8 @@
 # Sensu handler for sending to slack
 #
 class sensu_handlers::slack (
-  $webhook_url
+  $webhook_url,
+  $compact_message = false,
 ) inherits sensu_handlers {
 
   sensu::handler { 'slack':
@@ -13,8 +14,9 @@ class sensu_handlers::slack (
       $sensu_handlers::num_occurrences_filter,
     ]),
     config  => {
-      teams       => $teams,
-      webhook_url => $webhook_url,
+      teams           => $teams,
+      webhook_url     => $webhook_url,
+      compact_message => $compact_message,
     }
   }
 


### PR DESCRIPTION
added handler support for the setting in 09b7b0
this allows it to be set though the puppet module

sorry I forgot this bit in the original PR.