### PR TITLE
configurable default team pager

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -334,6 +334,11 @@ BODY
     "#{team_name}-pages"
   end
 
+  def default_pager
+    return [] if handler_settings['use_default_pager'] == false
+    default_pager_channel
+  end
+
   def find_channel(keys, &block)
     keys \
       .map(&block) \
@@ -353,7 +358,7 @@ BODY
   end
 
   def team_pager_channel
-    team_channel(pager_channel_keys) || default_pager_channel
+    team_channel(pager_channel_keys) || default_pager
   end
 
   def notifications_channel

--- a/files/base.rb
+++ b/files/base.rb
@@ -335,8 +335,8 @@ BODY
   end
 
   def default_pager
-    return [] if handler_settings['use_default_pager'] == false
-    default_pager_channel
+    return default_pager_channel if handler_settings.fetch('use_default_pager',true)
+    []
   end
 
   def find_channel(keys, &block)

--- a/files/hipchat.rb
+++ b/files/hipchat.rb
@@ -72,10 +72,6 @@ class Hipchat < BaseHandler
     %w[ hipchat_pager_room pager_room pager_channel ]
   end
 
-  def default_pager_channel
-    []
-  end
-
   # hipchat message room api takes a notify option: 
   #
   # Whether this message should trigger a user notification (change the tab

--- a/manifests/hipchat.pp
+++ b/manifests/hipchat.pp
@@ -25,8 +25,9 @@ class sensu_handlers::hipchat (
     type    => 'pipe',
     source  => 'puppet:///modules/sensu_handlers/hipchat.rb',
     config  => {
-      api_key      => $api_key,
-      teams        => $teams,
+      api_key           => $api_key,
+      teams             => $teams,
+      use_default_pager => $use_default_pager,
     }
   }
 

--- a/manifests/hipchat.pp
+++ b/manifests/hipchat.pp
@@ -9,6 +9,7 @@
 #  hipchat api key
 class sensu_handlers::hipchat (
   $api_key,
+  $use_default_pager = false, # backwards compatibility.
   $dependencies = {
     'hipchat' => {'provider' => $gem_provider }
   }

--- a/manifests/slack.pp
+++ b/manifests/slack.pp
@@ -3,7 +3,8 @@
 # Sensu handler for sending to slack
 #
 class sensu_handlers::slack (
-  $webhook_url
+  $webhook_url,
+  $use_default_pager = true,
 ) inherits sensu_handlers {
 
   sensu::handler { 'slack':

--- a/manifests/slack.pp
+++ b/manifests/slack.pp
@@ -14,8 +14,9 @@ class sensu_handlers::slack (
       $sensu_handlers::num_occurrences_filter,
     ]),
     config  => {
-      teams       => $teams,
-      webhook_url => $webhook_url,
+      teams             => $teams,
+      webhook_url       => $webhook_url,
+      use_default_pager => $use_default_pager,
     }
   }
 

--- a/spec/functions/base_spec.rb
+++ b/spec/functions/base_spec.rb
@@ -432,11 +432,12 @@ describe BaseHandler do
 
 
   describe "#channels" do
-    let(:team)       { 'someteam' }
-    let(:settings)   { subject.settings[settings_key] }
-    let(:team_data)  { settings['teams'][team] }
-    let(:check_data) { subject.event['check'] }
-    let(:channels)   { subject.channels }
+    let(:team)             { 'someteam' }
+    let(:settings)         { subject.settings[settings_key] }
+    let(:handler_settings) { subject.handler_settings }
+    let(:team_data)        { settings['teams'][team] }
+    let(:check_data)       { subject.event['check'] }
+    let(:channels)         { subject.channels }
 
     before do
       setup_event!({
@@ -452,7 +453,21 @@ describe BaseHandler do
       before { check_data['page'] = true }
 
       context "with no team or event level config"  do
-        it { expect(channels).to eq ["#{team}-pages"] }
+
+        context "when handler config has use_default_pager not set" do
+          it { expect(channels).to eq ["#{team}-pages"] }
+        end
+
+        context "when handler config has use_default_pager true" do
+          before { handler_settings['use_default_pager'] = true }
+          it { expect(channels).to eq ["#{team}-pages"] }
+        end
+
+        context "when handler config has use_default_pager false" do
+          before { handler_settings['use_default_pager'] = false }
+          it { expect(channels).to eq [] }
+        end
+
       end
 
       context "with both notification and pager channels configured at team leavel" do

--- a/spec/functions/hipchat_spec.rb
+++ b/spec/functions/hipchat_spec.rb
@@ -263,6 +263,8 @@ describe Hipchat do
 
   describe "rooms" do
     let(:rooms) { subject.rooms }
+    before { handler_settings['use_default_pager'] = false }
+
     context "event has page true" do
       before do
         check_data['page'] = true


### PR DESCRIPTION
allow the default team pager to be empty or #{team}-pager based off of
handler configuration use_default_pager

we never used the default pager channels in hipchat if teams didn't  set them
now we're cutting over to slack and don't want to try to alert to rooms that
don't exist.