### PR TITLE
Fix "component" support for Jira

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -59,7 +59,13 @@ class BaseHandler < Sensu::Handler
   end
 
   def component
-    "[" << Array(@event['check']['component'] || []).join(',') << "]"
+    if !@event['check']['component']
+      nil
+    elsif @event['check']['component'].is_a?(Array)
+      @event['check']['component']
+    else
+      [@event['check']['component']]
+    end
   end
 
   def team_name
@@ -140,7 +146,7 @@ Client Name: #{@event['client']['name']}
 Address:  #{@event['client']['address']}
 Check Name:  #{@event['check']['name']}
 Description: #{event_description}
-Component: #{component}
+Component: #{component || 'N/A'}
 
 BODY
     body
@@ -169,7 +175,7 @@ Client Name: {{#{@event['client']['name']}}}
 Address:  #{@event['client']['address']}
 Check Name:  #{@event['check']['name']}
 Description: #{event_description}
-Component: #{component}
+Component: #{component || 'N/A'}
 
 BODY
     body

--- a/files/jira.rb
+++ b/files/jira.rb
@@ -47,6 +47,11 @@ class Jira < BaseHandler
             "labels" => build_labels
           }
         }
+
+        if component
+          issue_json['fields'].merge!({'components' => component.map { |i| {'name' => i} }})
+        end
+
         issue.save(issue_json)
         url = get_options[:site] + '/browse/' + issue.key
         puts "Created issue #{issue.key} at #{url}"


### PR DESCRIPTION
The Jira handler doesn't really do components. Some projects (like KEW), won't let you create component-less tickets.  
This PR should fix.

With a component ([shootie](https://fluffy.yelpcorp.com/i/MqtR3PQ1cMwvbRxKHkWHd790khKNjtN9.png)):

```
gcioffi@admin1-uswest1adevc:~/sensu_handlers/files (fix_jira_component) $ echo '
> {
>   "client": {
>     "name": "random-hosta.prod.yelpcorp.com",
>     "address": "1.2.3.4"
>   },
>   "check": {
>     "thresholds": {
>       "warning": 120,
>       "critical": 180
>     },
>     "handlers": [
>       "default"
>     ],
>     "team": "operations",
>     "page": false,
>     "component": "Android",
>     "project": "PINCUSHION",
>     "ticket": true,
>     "alert_after": 300,
>     "realert_every": "-1",
>     "runbook": "y/rb-",
>     "notification_email": "undef",
>     "name": "test",
>     "issued": 1518077833,
>     "executed": 1518077833,
>     "output": "some output",
>     "status": 2,
>     "type": "standard",
>     "history": [],
>     "total_state_change": 0
>   },
>   "occurrences": 364083,
>   "action": "create",
>   "timestamp": 1518077833,
>   "id": "bogus",
>   "last_state_change": 1507148136,
>   "last_ok": null
> }
> ' | sudo ./jira.rb
warning: event filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin
warning: occurrence filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin
/var/lib/gems/2.3.0/gems/activesupport-3.2.19/lib/active_support/values/time_zone.rb:270: warning: circular argument reference - now
Creating a new jira ticket for: test on random-hosta.prod.yelpcorp.com is CRITICAL on project PINCUSHION
Created issue PINCUSHION-1926 at https://jira.yelpcorp.com:443/browse/PINCUSHION-1926
gcioffi@admin1-uswest1adevc:~/sensu_handlers/files (fix_jira_component) $
```

Without components ([shootie](https://fluffy.yelpcorp.com/i/7rxfW9mp3MhhGwFFlvD30r8PzkTbD2kK.png)):


```
gcioffi@admin1-uswest1adevc:~/sensu_handlers/files (fix_jira_component) $ echo '
> {
>   "client": {
>     "name": "random-hostb.prod.yelpcorp.com",
>     "address": "1.2.3.4"
>   },
>   "check": {
>     "thresholds": {
>       "warning": 120,
>       "critical": 180
>     },
>     "handlers": [
>       "default"
>     ],
>     "team": "operations",
>     "page": false,
>     "project": "PINCUSHION",
>     "ticket": true,
>     "alert_after": 300,
>     "realert_every": "-1",
>     "runbook": "y/rb-",
>     "notification_email": "undef",
>     "name": "test",
>     "issued": 1518077833,
>     "executed": 1518077833,
>     "output": "some output",
>     "status": 2,
>     "type": "standard",
>     "history": [],
>     "total_state_change": 0
>   },
>   "occurrences": 364083,
>   "action": "create",
>   "timestamp": 1518077833,
>   "id": "bogus",
>   "last_state_change": 1507148136,
>   "last_ok": null
> }
> ' | sudo ./jira.rb
warning: event filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin
warning: occurrence filtering in sensu-plugin is deprecated, see http://bit.ly/sensu-plugin
/var/lib/gems/2.3.0/gems/activesupport-3.2.19/lib/active_support/values/time_zone.rb:270: warning: circular argument reference - now
Creating a new jira ticket for: test on random-hostb.prod.yelpcorp.com is CRITICAL on project PINCUSHION
Created issue PINCUSHION-1927 at https://jira.yelpcorp.com:443/browse/PINCUSHION-1927
gcioffi@admin1-uswest1adevc:~/sensu_handlers/files (fix_jira_component) $
```

/cc @poros 