### PR TITLE
Support custom jira priorities

### DIFF
--- a/files/jira.rb
+++ b/files/jira.rb
@@ -116,6 +116,14 @@ class Jira < BaseHandler
   end
 
   def priority
+    # This uses a specific check's priority if given, but falls back to the
+    # default_priority of a team if specified in sensu_handlers::teams. This
+    # makes it easier if pseudo-teams are already specified like
+    # "ad_data_insights_p0" and "ad_data_insights_p1" to specify a default
+    # priority matching the team so that all their alert don't need to be
+    # updated to have the correct priority. If neither are found, this just
+    # returns nil, which will create a ticket with the default priority of
+    # whatever project it is created in.
     @event['check']['priority'] || team_data('default_priority')
   end
 

--- a/files/jira.rb
+++ b/files/jira.rb
@@ -52,6 +52,10 @@ class Jira < BaseHandler
           issue_json['fields'].merge!({'components' => component.map { |i| {'name' => i} }})
         end
 
+        if handler_settings['priority_map'].include?(priority)
+          issue_json['fields']['priority'] = {"name" => handler_settings['priority_map'][priority]}
+        end
+
         issue.save(issue_json)
         url = get_options[:site] + '/browse/' + issue.key
         puts "Created issue #{issue.key} at #{url}"
@@ -109,6 +113,10 @@ class Jira < BaseHandler
 
   def project
     @event['check']['project'] || team_data('project')
+  end
+
+  def priority
+    @event['check']['priority'] || team_data('default_priority')
   end
 
   def handle

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,14 @@
 #  If you are using the JIRA handler, it needs basic auth to work.
 #  Fill in the credentials and url to your local JIRA instance.
 #
+# [*jira_priority_map*]
+#  If you are using the JIRA handler, this is an optional setting that maps
+#  from a priority value to the priority name so that a simpler value can be
+#  passed in, since priorities can only be set by either ID or name. For
+#  example, if there is a priority 1 with a priority name '1 Do now', then
+#  a hash of { 1 => '1 Do now' } could be passed in here so that the whole
+#  priority name does not need to be specified in every sensu alert configured.
+#
 # [*use_embeded_ruby*]
 #  use provider => sensu_gem for any gem packages
 #
@@ -47,6 +55,7 @@ class sensu_handlers(
   $jira_username              = 'sensu',
   $jira_password              = 'sensu',
   $jira_site                  = "jira.${::domain}",
+  $jira_priority_map          = {},
   $mailer_runbook             = 'http://y/unkown',
   $mailer_server              = 'localhost',
   $mailer_tip                 = '',

--- a/manifests/jira.pp
+++ b/manifests/jira.pp
@@ -24,10 +24,11 @@ class sensu_handlers::jira (
     type    => 'pipe',
     source  => 'puppet:///modules/sensu_handlers/jira.rb',
     config  => {
-      teams    => $teams,
-      username => $jira_username,
-      password => $jira_password,
-      site     => $jira_site,
+      teams        => $teams,
+      username     => $jira_username,
+      password     => $jira_password,
+      site         => $jira_site,
+      priority_map => $jira_priority_map,
     },
     filters => flatten([
       'ticket_filter',

--- a/manifests/jira.pp
+++ b/manifests/jira.pp
@@ -35,17 +35,4 @@ class sensu_handlers::jira (
       $sensu_handlers::num_occurrences_filter,
     ]),
   }
-  if $::lsbdistcodename == 'Lucid' {
-    # So sorry for the httprb monkeypatch. It is Debian bug 564168 that took
-    # me forever to track down. Maybe someday we'll use a newer ruby.
-    # Afterall, who supports versions that are EOL?
-    # https://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/
-    # What are they going to deprecate next? ifconfig?
-    file_line { 'fix_httprb_564168':
-      match => '      @socket.close unless.*',
-      line  => '      @socket.close unless @socket.nil? || @socket.closed?',
-      path  => '/usr/lib/ruby/1.8/net/http.rb',
-    }
-  }
-
 }


### PR DESCRIPTION
I tested this by going on an admin host, editing `/etc/sensu/conf.d/handlers/jira.json` and adding this snippet at the end as a sample priority map (this will come from puppet hieradata instead, but this was just for testing):

```
"priority_map": {
  "0": "0 Drop everything",
  "1": "1 Do now",
  "2": "2 Do next"
}
```

I then took the snippet that @giuliano108 used for testing in #129 and modified it to have a `priority` parameter in the check set to `0` and it created PINCUSHION-1977 with the correct priority. Same with PINCUSHION-1978 when I set it to `2` (although that's also the default). With a priority not in the map, I tested and it just uses P2 as a fallback, and I also tested with something like `"0": "3 Nice to have"` (mostly for fun) and that also worked fine and created a P3 ticket when passed `0` as a check priority.

This whole mapping this is here because you can only set the priority of tickets by using the priority's name, or its ID. The IDs we have are something like 6 for a P0, 7 for a P1, etc. (not sure why it's offset), so I thought the names would make more sense, but didn't want to have to write out the whole priority name for each alert or wherever needed, so the map is there to convert from a short priority value to the full name (and make it easier to fix if the priorities change names in the future).

I also removed an old lucid patch for jira that we shouldn't need any more.