### PR TITLE
Fix build after bundler 2.x was released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,13 @@
 language: ruby
 bundler_args: --without development
 before_install:
-  - gem install bundler
+  - gem install bundler --version "< 2.0"
   - rm Gemfile.lock || true
 rvm:
-  - 1.8.7
   - 1.9.3
-  - 2.0.0
   - 2.1.0
 script: bundle exec rake spec
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.3.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.4.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-matrix:
-  exclude:
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 4.5.0" STRICT_VARIABLES=yes


### PR DESCRIPTION
This pins bundler to 1.x (since bundler 2.x requires newer ruby versions) and removes some older ruby/puppet versions we aren't using.

It also attempts to add puppet 4.5 to test against, although the `PUPPET_VERSION` environment variables in the build don't appear to have any effect, since puppet is pinned to a specific version (`3.6.2`) in the `Gemfile` anyway.

I would have added Ruby 2.3, but using that encounters [an issue](https://travis-ci.org/Yelp/sensu_handlers/jobs/477607380) because the syck module has been removed from ruby core and put into a gem, but puppet still thinks it's available by default. Hopefully using a newer puppet would work to fix that, but It seems like when that was tried in the past it was reverted: https://github.com/Yelp/sensu_handlers/commit/3673595c1689aecedb7484eb9a5a7a60063927cb

@solarkennedy What was the previous problem with upgrading puppet or allowing for multiple versions that led to the revert?