### PR TITLE
Fix mail titles to include the check output again

### DIFF
--- a/files/mailer.rb
+++ b/files/mailer.rb
@@ -59,7 +59,7 @@ class Mailer < BaseHandler
     # Only procede if we have an email address to work with
     return false unless mail_to
 
-    mail_from = handler_settings['mail_from']
+    mail_from = handler_settings['mail_from'] || 'sensu'
     return false unless mail_from
 
     delivery_method = handler_settings['delivery_method'] || 'smtp'
@@ -73,7 +73,7 @@ class Mailer < BaseHandler
     smtp_enable_starttls_auto = handler_settings['smtp_enable_starttls_auto'] == "false" ? false : true
 
     body = full_description
-    subject = "#{action_to_string} - #{short_name}: #{@event['check']['notification']}"
+    subject = "#{action_to_string} - #{short_name}: #{full_description.lines.first.strip}"
 
     Mail.defaults do
       delivery_options = {

--- a/spec/functions/mailer_spec.rb
+++ b/spec/functions/mailer_spec.rb
@@ -41,11 +41,12 @@ describe Mailer do
   end
 
   it "properly reads the email from the check" do
-    subject.event['check']['notification_email'] = "test@email"
+    subject.event['check']['notification_email'] = "test@example.com"
     subject.event['check']['status'] = 2
     subject.event['check']['name'] = 'fake_alert'
     subject.event['client']['name'] = 'fake_client'
-    Mail.stub(:deliver).and_return(true)
+    expect(Mail).to receive(:deliver)
+    expect(subject).not_to receive(:bail)
     subject.stub(:log).and_return(nil) # quiet specs
     subject.handle
   end


### PR DESCRIPTION
I thought for sure we used to have the first line in the output of our mail titles.

I'm not sure when this broke, but I don't see `@event['check']['notification']` anywhere. 

I couldn't figure out how to rspec test the subject directly, so I had to resort to manually printing to verify.