### PR TITLE
Add component support for individual teams (like tags)

### DIFF
--- a/files/base.rb
+++ b/files/base.rb
@@ -59,13 +59,10 @@ class BaseHandler < Sensu::Handler
   end
 
   def component
-    if !@event['check']['component']
-      nil
-    elsif @event['check']['component'].is_a?(Array)
-      @event['check']['component']
-    else
-      [@event['check']['component']]
-    end
+    [
+      *@event['check']['component'],
+      *team_data('component'),
+    ].uniq.reject(&:nil?)
   end
 
   def team_name

--- a/files/jira.rb
+++ b/files/jira.rb
@@ -48,7 +48,7 @@ class Jira < BaseHandler
           }
         }
 
-        if component
+        unless component.empty?
           issue_json['fields'].merge!({'components' => component.map { |i| {'name' => i} }})
         end
 


### PR DESCRIPTION
This adds component support so that components can be set per-team in `sensu_handlers::teams`. This is useful since the jira project is generally set per-team and components are required per-project, so being able to set components (like tags) per-team is useful.

I also changed the code for picking components to be a bit different and more similar to the way [labels/tags are currently constructed](https://github.com/Yelp/sensu_handlers/blob/a9ab8ea4686fdddae4c395257c599b7a1299446a/files/jira.rb#L11-L16):

```ruby
[
  *@event['check']['component'],
  *team_data('component'),
].uniq.reject(&:nil?)
```

Nicely enough, this handles `nil`, various values, and arrays as values without problems:

```ruby
irb(main):001:0> [*nil]
=> []
irb(main):002:0> [*5]
=> [5]
irb(main):003:0> [*[1, nil, 3]]
=> [1, nil, 3]
irb(main):004:0> [*5, *nil, *[1, 2, 'test']].uniq.reject(&:nil?)
=> [5, 1, 2, "test"]
```

I tested this by editing `/etc/sensu/conf.d/handlers/jira.json` on an admin server in dev and adding a default component to a team for testing and then using a technique like in #129 to make test tickets (but without a component explicitly set).