### PR TITLE
Optional Vault support (PEAUTO-42)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,7 @@ class sensu_handlers(
   $default_handler_array      = [ 'nodebot', 'pagerduty', 'mailer', 'jira' ],
   $jira_username              = 'sensu',
   $jira_password              = 'sensu',
+  $jira_password_source       = 'hiera',
   $jira_site                  = "jira.${::domain}",
   $jira_priority_map          = {},
   $mailer_runbook             = 'http://y/unkown',
@@ -72,6 +73,7 @@ class sensu_handlers(
 ) {
 
   validate_hash($teams, $api_client_config)
+  validate_re($jira_password_source, '^(hiera|vault)$')
 
   $gem_provider = $use_embedded_ruby ? {
     true    => 'sensu_gem',

--- a/manifests/jira.pp
+++ b/manifests/jira.pp
@@ -17,6 +17,11 @@ class sensu_handlers::jira (
     { before => Sensu::Handler['jira'] }
   )
 
+  case $jira_password_source {
+    'hiera': { $jira_password_real = $jira_password }
+    'vault': { $jira_password_real = vault_lookup('puppet/sensu_handlers/jira_password') }
+  }
+
   sensu::filter { 'ticket_filter':
     attributes => { 'check' => { 'ticket' => true } },
   } ->
@@ -26,7 +31,7 @@ class sensu_handlers::jira (
     config  => {
       teams        => $teams,
       username     => $jira_username,
-      password     => $jira_password,
+      password     => $jira_password_real,
       site         => $jira_site,
       priority_map => $jira_priority_map,
     },

--- a/spec/classes/jira_spec.rb
+++ b/spec/classes/jira_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'sensu_handlers::jira', :type => :class do
+
+  let(:facts) {{
+    :osfamily => 'Debian',
+    :lsbdistid => 'debian',
+  }}
+
+  let(:hiera_data) {{
+    'sensu_handlers::teams' => { 'operations' => {} },
+    'sensu_handlers::jira_password' => 'from_hiera',
+    'sensu_handlers::mailer::mail_from' => 'foo@bar.com',
+  }}
+
+  before(:each) do
+    Puppet::Parser::Functions.newfunction(:vault_lookup, :type => :rvalue) do |arguments|
+      'from_vault_lookup'
+    end
+  end
+
+  context 'by default' do
+    it 'obtains the Jira password from hiera' do
+      cfg = catalogue.resource('sensu::handler', 'jira').send(:parameters)[:config]
+      expect(cfg['password']).to eq('from_hiera')
+    end
+  end
+
+  context "when $jira_password_source = 'vault'" do
+    let(:hiera_data) { super().merge({ 'sensu_handlers::jira_password_source' => 'vault' }) }
+    it 'calls vault_lookup' do
+      cfg = catalogue.resource('sensu::handler', 'jira').send(:parameters)[:config]
+      expect(cfg['password']).to eq('from_vault_lookup')
+    end
+  end
+
+end


### PR DESCRIPTION
```
$ git rev-parse HEAD
657f412fa7708dc81539c7c4a4379d1f1ef04bdc
$ ruby --version
ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-darwin18.0]
$ bundle exec rake spec
[..]
Finished in 12.12 seconds
182 examples, 0 failures
```

```
$ bundle exec rake spec SPEC=spec/classes/jira_spec.rb  SPEC_OPTS='-f d'
sensu_handlers::jira
  by default
    obtains the Jira password from hiera
  when $jira_password_source = 'vault'
    calls vault_lookup

Finished in 4.18 seconds
2 examples, 0 failures
```
